### PR TITLE
now intellij can automatically attach sources to libraries

### DIFF
--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -32,7 +32,6 @@ trait MicroService {
     .settings(defaultSettings(): _*)
     .settings(
       libraryDependencies ++= appDependencies,
-      retrieveManaged := true,
       evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
       routesGenerator := StaticRoutesGenerator,
       routesImport ++= Seq(


### PR DESCRIPTION
This flag was set initially by platops team in template project. From my perspective it's not needed and disturbs in importing project into intellij.
Are they any circumstances why it's here?