### PR TITLE
Pawel/eeitt 985 test only endpoints

### DIFF
--- a/app/uk/gov/hmrc/gform/connectors/GformConnectors.scala
+++ b/app/uk/gov/hmrc/gform/connectors/GformConnectors.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost, HttpPut, HttpRes
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait BformsConnector {
+trait GformConnector {
 
   def httpGet : HttpGet
 
@@ -34,47 +34,47 @@ trait BformsConnector {
 
   def httpPut: HttpPut
 
-  def bformsUrl: String
+  def gformUrl: String
 
   def retrieveFormTemplate(formTypeId: FormTypeId, version: String)(implicit hc: HeaderCarrier, ec : ExecutionContext) : Future[Option[JsObject]] = {
-    httpGet.GET[Option[JsObject]](bformsUrl + s"/formtemplates/$formTypeId/$version")
+    httpGet.GET[Option[JsObject]](gformUrl + s"/formtemplates/$formTypeId/$version")
   }
 
   def saveForm(formDetails : JsValue, registrationNumber: String)(implicit hc : HeaderCarrier, ec : ExecutionContext) : Future[VerificationResult] = {
-    httpPost.POST[JsValue, VerificationResult](bformsUrl + s"/saveForm/$registrationNumber", formDetails)
+    httpPost.POST[JsValue, VerificationResult](gformUrl + s"/saveForm/$registrationNumber", formDetails)
   }
 
   def retrieveForm(registrationNumber: String)(implicit hc: HeaderCarrier, ec : ExecutionContext) : Future[JsObject] = {
-    httpPost.POSTString[JsObject](bformsUrl + s"/retrieveForm/$registrationNumber", registrationNumber)
+    httpPost.POSTString[JsObject](gformUrl + s"/retrieveForm/$registrationNumber", registrationNumber)
   }
 
   def submit(registrationNumber :String)(implicit hc: HeaderCarrier, ec : ExecutionContext) : Future[HttpResponse] ={
-    httpGet.GET[HttpResponse](bformsUrl+s"/submit/$registrationNumber")
+    httpGet.GET[HttpResponse](gformUrl+s"/submit/$registrationNumber")
   }
 
   def getById(formTypeId: FormTypeId, version: String, formId: FormId)(implicit hc : HeaderCarrier) : Future[FormData] = {
-    httpGet.GET[FormData](bformsUrl + s"/forms/$formTypeId/$version/$formId")
+    httpGet.GET[FormData](gformUrl + s"/forms/$formTypeId/$version/$formId")
   }
 
   def save(formDetails: FormData, tolerant: Boolean)(implicit hc : HeaderCarrier) : Future[SaveResult] = {
-    httpPost.POST[FormData, SaveResult](bformsUrl + s"/forms?tolerant=$tolerant", formDetails)
+    httpPost.POST[FormData, SaveResult](gformUrl + s"/forms?tolerant=$tolerant", formDetails)
   }
 
   def update(formId: FormId, formData: FormData, tolerant: Boolean)(implicit hc : HeaderCarrier) : Future[SaveResult] = {
-    httpPut.PUT[FormData, SaveResult](bformsUrl + s"/forms/$formId?tolerant=$tolerant", formData)
+    httpPut.PUT[FormData, SaveResult](gformUrl + s"/forms/$formId?tolerant=$tolerant", formData)
   }
 
   def sendSubmission(formTypeId: FormTypeId, formId: FormId)(implicit hc : HeaderCarrier) : Future[HttpResponse] = {
-    httpPost.POSTEmpty[HttpResponse](bformsUrl + s"/forms/$formTypeId/submission/$formId")
+    httpPost.POSTEmpty[HttpResponse](gformUrl + s"/forms/$formTypeId/submission/$formId")
   }
 }
 
-object BformsConnector extends BformsConnector with ServicesConfig {
+object GformConnector extends GformConnector with ServicesConfig {
 
   lazy val httpGet = WSHttp
   lazy val httpPost = WSHttp
   lazy val httpPut = WSHttp
 
-  def bformsUrl: String = s"${baseUrl("gform")}/gform"
+  def gformUrl: String = s"${baseUrl("gform")}/gform"
 
 }

--- a/app/uk/gov/hmrc/gform/controllers/TestOnly.scala
+++ b/app/uk/gov/hmrc/gform/controllers/TestOnly.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.controllers
+
+import javax.inject._
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.mvc._
+import uk.gov.hmrc.gform.controllers.helpers.ProxyActions
+import uk.gov.hmrc.play.config.ServicesConfig
+
+@Singleton
+class TestOnly @Inject()(proxy: ProxyActions ) extends Controller with ServicesConfig {
+
+  def proxyToGform(path: String): Action[Source[ByteString, _]] = proxy(gformBaseUrl)(path)
+
+  private lazy val gformBaseUrl = baseUrl("gform")
+}

--- a/app/uk/gov/hmrc/gform/controllers/helpers/ProxyActions.scala
+++ b/app/uk/gov/hmrc/gform/controllers/helpers/ProxyActions.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.controllers.helpers
+
+import javax.inject.{Inject, Singleton}
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.http.HttpEntity.Streamed
+import play.api.libs.streams.Accumulator
+import play.api.libs.ws.{StreamedBody, WSClient, WSRequest}
+import play.api.mvc._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.Future
+
+@Singleton
+class ProxyActions @Inject()(wsClient: WSClient) {
+
+  /**
+    * This creates actions which proxies incoming request to remote service.
+    */
+  def apply(remoteServiceBaseUrl: String)(path: String): Action[Source[ByteString, _]] = Action.async(streamedBodyParser) { (inboundRequest: Request[Source[ByteString, _]]) =>
+    for {
+      outboundRequest <- proxyRequest(s"$remoteServiceBaseUrl/$path", inboundRequest)
+      streamedResponse <- outboundRequest.stream
+    } yield {
+      val headersMap = streamedResponse.headers.headers
+      val contentLength = headersMap.get(contentLengthHeaderKey).flatMap(_.headOption.map(_.toLong))
+      val contentType = headersMap.get(contentTypeHeaderKey).map(_.mkString(", "))
+      Result(
+        ResponseHeader(streamedResponse.headers.status, streamedResponse.headers.headers.mapValues(_.head).filter(filterOutContentHeaders)),
+        Streamed(streamedResponse.body, contentLength, contentType)
+      )
+    }
+  }
+
+  private lazy val contentTypeHeaderKey = "Content-Type"
+  private lazy val contentLengthHeaderKey = "Content-Length"
+  private lazy val filterOutContentHeaders: ((String, String)) => Boolean = {
+    case (key, _) => !key.equalsIgnoreCase(contentTypeHeaderKey) && !key.equalsIgnoreCase(contentLengthHeaderKey)
+  }
+
+  private def proxyRequest(path: String, inboundRequest: Request[Source[ByteString, _]]): Future[WSRequest] = Future(
+    wsClient.url(s"$path")
+      .withFollowRedirects(false)
+      .withMethod(inboundRequest.method)
+      .withHeaders(processHeaders(inboundRequest.headers, extraHeaders = Nil): _*)
+      .withQueryString(inboundRequest.queryString.mapValues(_.head).toSeq: _*)
+      .withBody(StreamedBody(inboundRequest.body))
+  )
+
+  private def processHeaders(inboundHeaders: Headers, extraHeaders: Seq[(String, String)]): Seq[(String, String)] = {
+    inboundHeaders.toSimpleMap.filter(headerKeyValue => !headerKeyValue._1.equals("Host")) ++ extraHeaders.toMap toSeq
+  }
+
+  private def streamedBodyParser: BodyParser[Source[ByteString, _]] = BodyParser { _ => Accumulator.source[ByteString].map(Right.apply) }
+}

--- a/app/uk/gov/hmrc/gform/service/RetrieveService.scala
+++ b/app/uk/gov/hmrc/gform/service/RetrieveService.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-import uk.gov.hmrc.gform.connectors.BformsConnector
+import uk.gov.hmrc.gform.connectors.GformConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,7 +31,7 @@ import uk.gov.hmrc.gform.models.FormTemplate
 
 object RetrieveService {
 
-  def bformsConnector = BformsConnector
+  def bformsConnector = GformConnector
 
   def formTemplateFromJson(formTemplate: JsObject): Either[String, FormTemplate] = {
     formTemplate.validate[FormTemplate] match {

--- a/app/uk/gov/hmrc/gform/service/SaveService.scala
+++ b/app/uk/gov/hmrc/gform/service/SaveService.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.gform.service
 
 import scala.concurrent.ExecutionContext
-import uk.gov.hmrc.gform.connectors.BformsConnector
+import uk.gov.hmrc.gform.connectors.GformConnector
 import uk.gov.hmrc.gform.models.{SaveResult, VerificationResult}
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 
@@ -28,7 +28,7 @@ import uk.gov.hmrc.gform.models.form.{FormData, FormId, FormTypeId}
 
 object SaveService {
 
-  def bformsConnector : BformsConnector = BformsConnector
+  def bformsConnector : GformConnector = GformConnector
 
   def getFormById(formTypeId: FormTypeId, version: String, formId: FormId)(implicit hc : HeaderCarrier) = {
     bformsConnector.getById(formTypeId, version, formId)

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,8 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+GET        /test-only/proxy-to-gform/*path             @uk.gov.hmrc.gform.controllers.TestOnly.proxyToGform(path: String)
+POST       /test-only/proxy-to-gform/*path             @uk.gov.hmrc.gform.controllers.TestOnly.proxyToGform(path: String)
+PUT        /test-only/proxy-to-gform/*path             @uk.gov.hmrc.gform.controllers.TestOnly.proxyToGform(path: String)
+PATCH      /test-only/proxy-to-gform/*path             @uk.gov.hmrc.gform.controllers.TestOnly.proxyToGform(path: String)
+DELETE     /test-only/proxy-to-gform/*path             @uk.gov.hmrc.gform.controllers.TestOnly.proxyToGform(path: String)


### PR DESCRIPTION
Running sbt like this ` sbt run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes` will expose `/test-only/proxy-to-gform/<GFORM_PATH>`