### PR TITLE
Fix bug in date validation introduced by changes in address validation

### DIFF
--- a/app/uk/gov/hmrc/gform/service/ValidationService.scala
+++ b/app/uk/gov/hmrc/gform/service/ValidationService.scala
@@ -85,21 +85,23 @@ object ValidationService {
 
     val dataGetter: FieldValue => String => Seq[String] = fv => suffix => data.get(fv.id.withSuffix(suffix)).toList.flatten
 
-    def validateRF(value: String) = validateRequired(fieldValue.id.withJSSafeSuffix(value)) _
-    def validateFF(value: String) = validateForbidden(fieldValue.id.withJSSafeSuffix(value)) _
+    def validateRF(value: String) = validateRequired(fieldValue.id.withSuffix(value)) _
+    def validateFF(value: String) = validateForbidden(fieldValue.id.withSuffix(value)) _
 
     def validateAddress(fieldValue: FieldValue, address: Address)(data: Map[FieldId, Seq[String]]): ValidatedType = {
       val addressValueOf: String => Seq[String] = suffix => data.get(fieldValue.id.withJSSafeSuffix(suffix)).toList.flatten
+      def validateRequiredFied(value: String) = validateRequired(fieldValue.id.withJSSafeSuffix(value)) _
+      def validateForbiddenField(value: String) = validateForbidden(fieldValue.id.withJSSafeSuffix(value)) _
 
       val validatedResult: List[ValidatedType] = addressValueOf("uk") match {
         case "true" :: Nil =>
-          List(validateRF("street1")(addressValueOf("street1")),
-            validateRF("postcode")(addressValueOf("postcode")),
-            validateFF("country")(addressValueOf("country")))
+          List(validateRequiredFied("street1")(addressValueOf("street1")),
+            validateRequiredFied("postcode")(addressValueOf("postcode")),
+            validateForbiddenField("country")(addressValueOf("country")))
         case _ =>
-          List(validateRF("street1")(addressValueOf("street1")),
-            validateFF("postcode")(addressValueOf("postcode")),
-            validateRF("country")(addressValueOf("country")))
+          List(validateRequiredFied("street1")(addressValueOf("street1")),
+            validateForbiddenField("postcode")(addressValueOf("postcode")),
+            validateRequiredFied("country")(addressValueOf("country")))
       }
 
       Monoid[ValidatedType].combineAll(validatedResult)

--- a/test/uk/gov/hmrc/gform/services/AddressValidationSpec.scala
+++ b/test/uk/gov/hmrc/gform/services/AddressValidationSpec.scala
@@ -141,4 +141,22 @@ class AddressValidationSpec extends FlatSpec with Matchers with EitherMatchers {
       speccedAddress.id.withJSSafeSuffix("country") -> Set("must not be entered")))
   }
 
+  "Address validation" should "fail when field separator is wrong" in {
+    val address = Address(international = true)
+
+    val speccedAddress = FieldValue(FieldId("x"), address, "l", None, true, true, false)
+
+    val data = Map(FieldId("x@uk") -> Seq("true"),
+      FieldId("x@street1") -> Seq("S"),
+      FieldId("x@country") -> Seq("C"))
+
+    val result: ValidatedType = CompData(speccedAddress, data).validateComponents
+
+    result.toEither should beLeft(
+      Map(
+        FieldId("x-country") -> Set("must be entered"),
+        FieldId("x-street1") -> Set("must be entered")
+      )
+    )
+  }
 }

--- a/test/uk/gov/hmrc/gform/services/DateValidationSpec.scala
+++ b/test/uk/gov/hmrc/gform/services/DateValidationSpec.scala
@@ -275,4 +275,20 @@ class DateValidationSpec extends FlatSpec with Matchers with EitherMatchers {
     result.toEither should beLeft(Map(fieldValue.id.withSuffix("day") -> Set(s"must be non-numeric"),
                                       fieldValue.id.withSuffix("month") -> Set(s"must be non-numeric")))
   }
+
+  "Date validations" should "fail if field ids are using wrong separator" in {
+    val date = Date(AnyDate, Offset(0), None)
+
+    val fieldValue = FieldValue(FieldId("accPeriodStartDate"), date,
+      "sample label", None, false,
+      false, false)
+
+    val data = Map(FieldId("accPeriodStartDate-day") -> Seq("01"),
+      FieldId("accPeriodStartDate-month") -> Seq("01"),
+      FieldId("accPeriodStartDate-year") -> Seq("1970"))
+
+    val result: ValidatedType = CompData(fieldValue, data).validateComponents
+
+    result.toEither should beLeft(Map(FieldId("accPeriodStartDate") -> Set("Date is missing")))
+  }
 }


### PR DESCRIPTION
Fix validation code calling withJSSafeSuffix instead of withSuffix for data validation. Added tests for date and address validation to make sure the right separator is used