### PR TITLE
Remove commas and pound signs from numeric values

### DIFF
--- a/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
+++ b/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
@@ -43,7 +43,7 @@ object Javascript {
        """.stripMargin
     }
 
-    def values(id: String) = s"""parseInt(document.getElementById("$id").value) || 0"""
+    def values(id: String) = s"""parseInt(document.getElementById("$id").value.replace(/[£,]/g,'')) || 0"""
 
     def ids(expr: Expr): List[String] = {
       expr match {


### PR DESCRIPTION
Remove commas and pound signs from numeric values in javascript in order to allow dynamic calculations to be performed on numeric values