### PR TITLE
GFC-52 safari summary fix

### DIFF
--- a/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
+++ b/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
@@ -47,7 +47,7 @@
       Make sure that the information you have given is correct before submitting your @{formCategory.getString}.
     </p>
 
-    <form action="@uk.gov.hmrc.gform.gform.routes.SummaryController.submit(formId, formTemplate._id, summary.totalPage, lang).url" method="POST" class="js-form" autocomplete="off" novalidate="novalidate">
+    <form action="@uk.gov.hmrc.gform.gform.routes.SummaryController.submit(formId, formTemplate._id, summary.totalPage, lang).url" method="POST" class="js-form" autocomplete="off" novalidate="novalidate" id="gform">
 
         @{
             CSRF.formField
@@ -72,11 +72,11 @@
 
         <div class="print-hidden">
           <div class="form-group divider--top--thick">
-              <button type="submit" class="button" name="save" value="Declaration">Save and continue</button>
+              <button type="submit" class="button" value="Declaration">Save and continue</button>
           </div>
 
           <div class="form-group">
-              <button type="submit" class="button--secondary" name="save" value="Exit">Save and come back later</button>
+              <button type="submit" class="button--secondary" value="Exit">Save and come back later</button>
           </div>
         </div>
     </form>

--- a/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
+++ b/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
@@ -47,7 +47,7 @@
       Make sure that the information you have given is correct before submitting your @{formCategory.getString}.
     </p>
 
-    <form action="@uk.gov.hmrc.gform.gform.routes.SummaryController.submit(formId, formTemplate._id, summary.totalPage, lang).url" method="POST" class="js-form" autocomplete="off" novalidate="novalidate" id="gform">
+    <form action="@uk.gov.hmrc.gform.gform.routes.SummaryController.submit(formId, formTemplate._id, summary.totalPage, lang).url" method="POST" class="js-form" autocomplete="off" novalidate="novalidate" id="gf-form">
 
         @{
             CSRF.formField
@@ -70,14 +70,17 @@
           </p>
         </div>
 
-        <div class="print-hidden">
-          <div class="form-group divider--top--thick">
-              <button type="submit" class="button" value="Declaration">Save and continue</button>
-          </div>
+        <input type="hidden" id="gform-action" name="save" value="Declaration" />
 
-          <div class="form-group">
-              <button type="submit" class="button--secondary" value="Exit">Save and come back later</button>
-          </div>
+        <div class="print-hidden">
+            <div class="form-group divider--top--thick">
+                <button type="submit" class="button" value="Declaration">Save and continue</button>
+            </div>
+            <div class="js-visible">
+                <div class="form-group">
+                    <button type="submit" class="button--secondary" value="Exit">Save and come back later</button>
+                </div>
+            </div>
         </div>
     </form>
 


### PR DESCRIPTION
This fixes the summary for the Safari browser, in the same way that it was earlier fixed for form sections by Paul in commit 63c59fa9a010fa6dbe651f311eb559d8c64abddc