### PR TITLE
GFC-285 Adds focus class to upload label for firefox outline

### DIFF
--- a/public/javascripts/gform.js
+++ b/public/javascripts/gform.js
@@ -271,4 +271,14 @@ $('#backButton').on("click",function(){
     $('#gform-action').attr('value', 'Back');
 });
 
+// Add focus class to file upload label on input focus for outline in firefox
+$('.file-upload__file').focus(function(){
+    $(this).siblings('.file-upload__file-label').addClass('focus');
+})
+
+$('.file-upload__file').blur(function(){
+    $(this).siblings('.file-upload__file-label').removeClass('focus');
+});
+
+
 showHideContent.init();

--- a/public/stylesheets/gform.css
+++ b/public/stylesheets/gform.css
@@ -116,7 +116,7 @@
   margin: 10px 0 0 0;
 }
 
-.file-upload__file:focus + .file-upload__file-label {
+.file-upload__file:focus + .file-upload__file-label, .file-upload__file-label.focus {
   outline: 3px solid #ffbf47;
 }
 


### PR DESCRIPTION
Adds a focus class to the label adjacent to the file upload input when the input gains focus. 
This is to show the focus outline for the element in Firefox - this pattern was taken from the upload file button used across GOV.UK - for example uploading a passport photo when applying for a passport.