### PR TITLE
Subtract one number from another in Javascript correctly

### DIFF
--- a/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
+++ b/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
@@ -179,7 +179,7 @@ object Javascript {
         } yield {
           s"""|function $functionName() {
               |  var x = [ $values ];
-              |  var result = x.reduce(subtract, 0);
+              |  var result = subtract(x[0], x[1]);
               |  document.getElementById("${field.id.value}").value = result.toFixed($roundTo, 0);
               |  return document.getElementById("${field.id.value}-total").innerHTML = result.toFixed($roundTo, 0);
               |};


### PR DESCRIPTION
Subtract one number from another in Javascript correctly, GFC-323, rather than incorrectly using reduce()