### PR TITLE
GFC-284 Convert back buttons to links

### DIFF
--- a/app/uk/gov/hmrc/gform/views/form/form.scala.html
+++ b/app/uk/gov/hmrc/gform/views/form/form.scala.html
@@ -47,7 +47,7 @@
     }
     @if(shouldDisplayBack){
      <div class="form-group js-visible">
-      <button type="button" form="gf-form"  id="backButton"  class="link-back" value="Back">Back</button>
+      <a href="#" class="link-back" id="backButton">Back</a>
     </div>
     }
     <h1 class="h1-heading form-title">@localisation(page.sectionTitle)</h1>
@@ -83,7 +83,7 @@
 
           @if(shouldDisplayBackToSummary){
             <div class="form-group">
-              <button type="submit" class="link-back"  value="BackToSummary">Back to summary</button>
+              <a href="#" class="link-back" id="BackToSummary">Back to summary</a>
             </div>
           }
 

--- a/public/javascripts/gform.js
+++ b/public/javascripts/gform.js
@@ -257,19 +257,19 @@ gfForm.on('click', '[type="submit"]', function(evt) {
   gfFormAction.val(type);
 });
 
-// Avoid the browser choosing the 'Back' button when the user presses Enter, unless the button
-// is in focus.
-$("#backButton").focus(function(){
-  $(this).attr('type', 'submit');
+// Manually submit the form with the action saving the form and taking the user back one screen
+$('#backButton').on("click",function(e){
+    e.preventDefault();
+    gfFormAction.attr('value', 'Back');
+    gfForm.submit();
 });
 
-$('#backButton').blur(function(){
-  $(this).attr('type', 'button');
-});
-
-$('#backButton').on("click",function(){
-    $('#gform-action').attr('value', 'Back');
-});
+// Manually submit the form with the action taking the user back to the summary page
+$('#BackToSummary').on('click', function(e) {
+    e.preventDefault();
+    gfFormAction.attr('value', 'BackToSummary');
+    gfForm.submit();
+})
 
 // Add focus class to file upload label on input focus for outline in firefox
 $('.file-upload__file').focus(function(){

--- a/public/stylesheets/gform.css
+++ b/public/stylesheets/gform.css
@@ -157,33 +157,6 @@
   font-weight: bold;
 }
 
-/* Make back button look like a ba ck link, CSS specificity means we can't just apply the link class */
-button.link-back {
-  background: transparent;
-  box-shadow: none;
-  border-top: 1px solid transparent;
-  border-bottom-color: black;
-  padding-top: 0;
-  padding-right: 0;
-  padding-bottom: 0;
-}
-
-button.link-back:focus {
-  color: #0B0C09;
-  background: #FFBF47;
-  outline: 3px solid #ffbf47;
-  outline-offset: 0; /* overwrite styles from button pattern */
-}
-
-/* Overwrite button styling attributes interfering with link-back arrow setup */
-button.link-back:before {
-  top: 50%;
-  height: 0;
-}
-button.link-back:active {
-  top: 0;
-}
-
 button.button--secondary{
     border: 3px solid transparent;
 }


### PR DESCRIPTION
This switches out the back links to be anchor links as opposed to HTML buttons. 
The buttons were causing numerous style issues - and were not working in IE as the button form attribute is not supported in IE yet.