### PR TITLE
GFC-356 Re-implement required styles for uploaded file list item/s

### DIFF
--- a/public/stylesheets/gform.css
+++ b/public/stylesheets/gform.css
@@ -48,6 +48,21 @@
   margin-right: 0;
 }
 
+/* File uploader */
+.file-upload__file-list {
+  margin: 0;
+  padding: 0;
+}
+
+.file-upload__file-list-item {
+  margin: 0;
+  padding: 0;
+}
+
+.file-upload__file-list-item .gf-delete {
+  margin-left: 1em;
+}
+
 /* Info components */
 .panel-info ul {
   margin-left: 1em;


### PR DESCRIPTION
In removing the styles which altered the default File Upload pattern to be a custom implementation, some required styles for the list of uploaded files was removed. 

This adds back in the required styles.