### PR TITLE
Suppress Javascript calculations which are purely static

### DIFF
--- a/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
+++ b/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
@@ -26,7 +26,7 @@
 
 @(
     formTemplate: FormTemplate,
-        snippets: List[Html],
+    snippets: List[Html],
     formId: FormId,
     formCategory: FormCategory,
     lang: Option[String],

--- a/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
+++ b/app/uk/gov/hmrc/gform/views/summary/summary.scala.html
@@ -18,7 +18,6 @@
 @import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 @import uk.gov.hmrc.gform.models._
 @import uk.gov.hmrc.gform.views.html._
-@import uk.gov.hmrc.gform.summary.SummaryForRender
 @import views.html.helper.CSRF
 @import scala.concurrent.ExecutionContext
 @import uk.gov.hmrc.gform.config.FrontendAppConfig
@@ -27,7 +26,7 @@
 
 @(
     formTemplate: FormTemplate,
-    summary: SummaryForRender,
+        snippets: List[Html],
     formId: FormId,
     formCategory: FormCategory,
     lang: Option[String],
@@ -57,7 +56,7 @@
         }
 
       	@{
-      	    summary.snippets
+      	    snippets
       	}
 
       	<input type="hidden"
@@ -87,8 +86,4 @@
         </div>
     </form>
 
-    <script type="text/javascript">
-
-      @summary.javascripts
-    </script>
 }

--- a/test/uk/gov/hmrc/gform/models/SummarySpec.scala
+++ b/test/uk/gov/hmrc/gform/models/SummarySpec.scala
@@ -83,8 +83,8 @@ class SummarySpec extends Spec {
 
   "Summary" should "display the summary sections" in new Test {
     val render = SummaryRenderingService.summaryForRender(f, rawDataFromBrowser, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    render.futureValue.snippets.size should be(9)
-    extractAllTestStringValues(render.futureValue.snippets) should be(List("Your details", "About you", "Business details"))
+    render.futureValue.size should be(9)
+    extractAllTestStringValues(render.futureValue) should be(List("Your details", "About you", "Business details"))
   }
 
   it should "display links to page sections" in new Test {
@@ -92,7 +92,7 @@ class SummarySpec extends Spec {
 
     val render = SummaryRenderingService.summaryForRender(f, Map(), retrievals, formId, formTemplate, mockRepeatService, envelope, None)
 
-    val testStringValues = extractAllHrefs(render.futureValue.snippets)
+    val testStringValues = extractAllHrefs(render.futureValue)
 
     def callUrlEscaped(call: Call) = call.url.replaceAll("&", "&amp;")
 
@@ -131,15 +131,15 @@ class SummarySpec extends Spec {
 
     override def fieldValues = formTemplate.sections.flatMap(_.fields)
     val render = SummaryRenderingService.summaryForRender(f, rawDataFromBrowser, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val testStringValues = extractAllTestStringValues(render.futureValue.snippets)
+    val testStringValues = extractAllTestStringValues(render.futureValue)
     testStringValues should be(List("Saxe-Coburg-Gotha", "Street", "Second Street", "Third Street", "Town", "PO32 6JX", "UK"))
-    extractDates(render.futureValue.snippets) should be(List(("19", "November", "1841")))
+    extractDates(render.futureValue) should be(List(("19", "November", "1841")))
   }
 
   it should "display the title when shortName is not present in the section" in new Test {
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
 
-    val doc = Jsoup.parse(render.futureValue.snippets.head.toString())
+    val doc = Jsoup.parse(render.futureValue.head.toString())
     println(doc.getElementsByTag("SPAN").text())
     doc.getElementsByTag("SPAN").text().toLowerCase should include("your details")
   }
@@ -150,7 +150,7 @@ class SummarySpec extends Spec {
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
 
-    val doc = Jsoup.parse(render.futureValue.snippets.head.toString())
+    val doc = Jsoup.parse(render.futureValue.head.toString())
     doc.getElementsByTag("SPAN").text().toUpperCase should include(shortName)
   }
 
@@ -173,7 +173,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("Address section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(shortName) shouldBe true
   }
 
@@ -195,7 +195,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("Address section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(label) shouldBe true
   }
 
@@ -218,7 +218,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("A section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(shortName) shouldBe true
   }
 
@@ -241,7 +241,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("A section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(label) shouldBe true
   }
 
@@ -264,7 +264,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("A section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(shortName) shouldBe true
   }
 
@@ -288,7 +288,7 @@ class SummarySpec extends Spec {
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     //    override val f: FieldValue => Option[FormFieldValidationResult] = okValues(Map.empty, fieldValues, envelope)
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(label) shouldBe true
   }
 
@@ -311,7 +311,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("A section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(shortName) shouldBe true
   }
 
@@ -334,7 +334,7 @@ class SummarySpec extends Spec {
     val section = section0.copy(fields = List(addressField), shortName = Some("A section"))
     override val formTemplate = super.formTemplate.copy(sections = List(section))
     val render = SummaryRenderingService.summaryForRender(f, Map.empty, retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val doc = Jsoup.parse(render.futureValue.snippets.mkString)
+    val doc = Jsoup.parse(render.futureValue.mkString)
     doc.getElementsByTag("TBODY").first().getElementsByTag("TD").first().text().equals(label) shouldBe true
   }
 
@@ -345,9 +345,9 @@ class SummarySpec extends Spec {
       sections = List(section1)
     )
     val renderWithDataMatching = SummaryRenderingService.summaryForRender(f, Map(FormComponentId("firstName") -> Seq("Pete")), retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    renderWithDataMatching.futureValue.snippets.size shouldBe 3
+    renderWithDataMatching.futureValue.size shouldBe 3
     val renderWithDataMismatch = SummaryRenderingService.summaryForRender(f, Map(FormComponentId("firstName") -> Seq("*Not*Pete")), retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    renderWithDataMismatch.futureValue.snippets.size shouldBe 0
+    renderWithDataMismatch.futureValue.size shouldBe 0
   }
 
   it should "display Group Labels (or Group Short Names if specified)" in new Test {
@@ -363,14 +363,14 @@ class SummarySpec extends Spec {
     override def section0 = Section("", None, None, None, None, None, None, None, List(groupFieldValue))
     override def formTemplate = super.formTemplate.copy(sections = List(section0))
     val render0 = SummaryRenderingService.summaryForRender(f, Map.empty[FormComponentId, Seq[String]], retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    extractAllTestStringValues(render0.futureValue.snippets) should be(List("group-label"))
+    extractAllTestStringValues(render0.futureValue) should be(List("group-label"))
     val formTemplateWGroupWithShortname = formTemplate.copy(
       sections = List(Section("", None, None, None, None, None, None, None, List(groupFieldValue.copy(shortName = Some("Test!group-shortname!Test")))))
     )
 
     val filedValues1 = formTemplate.sections.flatMap(_.fields)
     val render1 = SummaryRenderingService.summaryForRender(f, Map.empty[FormComponentId, Seq[String]], retrievals, formId, formTemplateWGroupWithShortname, mockRepeatService, envelope, None)
-    extractAllTestStringValues(render1.futureValue.snippets) should be(List("group-shortname"))
+    extractAllTestStringValues(render1.futureValue) should be(List("group-shortname"))
   }
 
   "The Change hrefs" should "link to the correct page" in new Test {
@@ -381,7 +381,7 @@ class SummarySpec extends Spec {
     //    override val f: FieldValue => Option[FormFieldValidationResult] = okValues(Map(FieldId("firstName") -> Seq("*Not*Pete")), fieldValues, envelope)
 
     val summaryForRender = SummaryRenderingService.summaryForRender(f, Map(FormComponentId("firstName") -> Seq("*Not*Pete")), retrievals, formId, formTemplate, mockRepeatService, envelope, None)
-    val htmls = summaryForRender.futureValue.snippets
+    val htmls = summaryForRender.futureValue
     val htmlAheadOfSection2 = htmls(3)
     val doc = Jsoup.parse(htmlAheadOfSection2.toString)
     val urlOfHrefToSection2 = doc.select("a:contains(Change)").get(0).attributes().get("href")

--- a/test/uk/gov/hmrc/gform/models/helpers/JavascriptSpec.scala
+++ b/test/uk/gov/hmrc/gform/models/helpers/JavascriptSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.gform.models.helpers
 
 import cats.implicits._
@@ -10,19 +26,8 @@ class JavascriptSpec extends Spec {
 
   private val c = Constant("")
 
-  def formComponent(id: String, value : Expr = c) = FormComponent(
-    FormComponentId(id),
-    Text(AnyText, value),
-    "",
-    None,
-    None,
-    None,
-    false,
-    true,
-    true,
-    true,
-    false,
-    None)
+  def formComponent(id: String, value: Expr = c) =
+    FormComponent(FormComponentId(id), Text(AnyText, value), "", None, None, None, false, true, true, true, false, None)
 
   private def fieldJavascript(field: FormComponent) = {
     val fields = List(formComponent("thisSection"), field)
@@ -32,34 +37,31 @@ class JavascriptSpec extends Spec {
       groupList = List[List[List[FormComponent]]]().pure[Future])
   }
 
-  "if calculation references only a constant" should "not generate Javascript for the static calculation" in{
+  "if calculation references only a constant" should "not generate Javascript for the static calculation" in {
     val result = fieldJavascript(formComponent("staticExpr"))
-    result.futureValue should not include("addstaticExpr")
+    result.futureValue should not include ("addstaticExpr")
   }
 
-  "if calculation references only a field in this section" should "not generate Javascript for the static calculation" in{
+  "if calculation references only a field in this section" should "not generate Javascript for the static calculation" in {
     val result = fieldJavascript(formComponent("staticExpr", FormCtx("thisSection")))
-    result.futureValue should not include("addstaticExpr")
+    result.futureValue should not include ("addstaticExpr")
   }
 
-  "if calculation references only a group in this section" should "generate Javascript for the dynamic calculation" in{
+  "if calculation references only a group in this section" should "generate Javascript for the dynamic calculation" in {
     val result = fieldJavascript(formComponent("dynamicExpr", Sum(FormCtx("thisSection"))))
     result.futureValue should include("sumthisSection")
   }
 
-  "if calculation adds a field in this section" should "generate Javascript for the dynamic calculation" in{
+  "if calculation adds a field in this section" should "generate Javascript for the dynamic calculation" in {
     val result = fieldJavascript(formComponent("dynamicExpr", Add(FormCtx("thisSection"), c)))
     result.futureValue should include("adddynamicExpr")
   }
 
-  "if calculation deep inside uses a field in this section" should "generate Javascript for the dynamic calculation" in{
-    val result = fieldJavascript(formComponent("dynamicExpr",
-      Add(c, Add(
-        Subtraction(c, Subtraction(
-          Multiply( c, Multiply(FormCtx("thisSection"), c)),
-          c)),
-        c))
-    ))
+  "if calculation deep inside uses a field in this section" should "generate Javascript for the dynamic calculation" in {
+    val result = fieldJavascript(
+      formComponent(
+        "dynamicExpr",
+        Add(c, Add(Subtraction(c, Subtraction(Multiply(c, Multiply(FormCtx("thisSection"), c)), c)), c))))
     result.futureValue should include("adddynamicExpr")
   }
 

--- a/test/uk/gov/hmrc/gform/models/helpers/JavascriptSpec.scala
+++ b/test/uk/gov/hmrc/gform/models/helpers/JavascriptSpec.scala
@@ -1,0 +1,66 @@
+package uk.gov.hmrc.gform.models.helpers
+
+import cats.implicits._
+import uk.gov.hmrc.gform.Spec
+import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+
+import scala.concurrent.Future
+
+class JavascriptSpec extends Spec {
+
+  private val c = Constant("")
+
+  def formComponent(id: String, value : Expr = c) = FormComponent(
+    FormComponentId(id),
+    Text(AnyText, value),
+    "",
+    None,
+    None,
+    None,
+    false,
+    true,
+    true,
+    true,
+    false,
+    None)
+
+  private def fieldJavascript(field: FormComponent) = {
+    val fields = List(formComponent("thisSection"), field)
+    Javascript.fieldJavascript(
+      sectionFields = fields,
+      allFields = formComponent("otherSection") :: fields,
+      groupList = List[List[List[FormComponent]]]().pure[Future])
+  }
+
+  "if calculation references only a constant" should "not generate Javascript for the static calculation" in{
+    val result = fieldJavascript(formComponent("staticExpr"))
+    result.futureValue should not include("addstaticExpr")
+  }
+
+  "if calculation references only a field in this section" should "not generate Javascript for the static calculation" in{
+    val result = fieldJavascript(formComponent("staticExpr", FormCtx("thisSection")))
+    result.futureValue should not include("addstaticExpr")
+  }
+
+  "if calculation references only a group in this section" should "generate Javascript for the dynamic calculation" in{
+    val result = fieldJavascript(formComponent("dynamicExpr", Sum(FormCtx("thisSection"))))
+    result.futureValue should include("sumthisSection")
+  }
+
+  "if calculation adds a field in this section" should "generate Javascript for the dynamic calculation" in{
+    val result = fieldJavascript(formComponent("dynamicExpr", Add(FormCtx("thisSection"), c)))
+    result.futureValue should include("adddynamicExpr")
+  }
+
+  "if calculation deep inside uses a field in this section" should "generate Javascript for the dynamic calculation" in{
+    val result = fieldJavascript(formComponent("dynamicExpr",
+      Add(c, Add(
+        Subtraction(c, Subtraction(
+          Multiply( c, Multiply(FormCtx("thisSection"), c)),
+          c)),
+        c))
+    ))
+    result.futureValue should include("adddynamicExpr")
+  }
+
+}


### PR DESCRIPTION
Suppress Javascript calculations which are purely static, i.e. dependent only on fields from other sections

Interim

Compiles, needs tests

Add unit tests