### PR TITLE
GFC-480 Add reverse route for delete after save and exit

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/FormController.scala
+++ b/app/uk/gov/hmrc/gform/gform/FormController.scala
@@ -273,6 +273,8 @@ class FormController(
       gformConnector.deleteForm(formId).map(_ => Redirect(routes.FormController.newForm(cache.formTemplate._id, lang)))
     }
 
+  val deleteOnExit = delete _
+
   def updateFormData(formId: FormId, sectionNumber: SectionNumber, lang: Option[String]) = auth.async(formId) {
     implicit request => cache =>
       val envelopeF = for {

--- a/app/uk/gov/hmrc/gform/views/hardcoded/pages/save_acknowledgement.scala.html
+++ b/app/uk/gov/hmrc/gform/views/hardcoded/pages/save_acknowledgement.scala.html
@@ -59,7 +59,7 @@
     the form
 </li>
 <li>delete and
-    <a href="@uk.gov.hmrc.gform.gform.routes.FormController.delete(formTemplate._id.to4Ga, formId, lang)">
+    <a href="@uk.gov.hmrc.gform.gform.routes.FormController.deleteOnExit(formTemplate._id.to4Ga, formId, lang)">
         Start again
     </a>
 </li>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,6 +14,8 @@ POST          /form/:formTemplateId/:formId/decision                            
 POST          /form/:formTemplateId4Ga/:formId/delete                                                            uk.gov.hmrc.gform.gform.FormController.delete(formTemplateId4Ga: FormTemplateId4Ga, formId: FormId, lang: Option[String])
 POST          /form/:formId/:sectionNumber                                                                       uk.gov.hmrc.gform.gform.FormController.updateFormData(formId: FormId, sectionNumber: SectionNumber, lang: Option[String])
 
+GET           /delete/:formTemplateId4Ga                                                                         uk.gov.hmrc.gform.gform.FormController.deleteOnExit(formTemplateId4Ga: FormTemplateId4Ga, i: FormId, lang: Option[String])
+
 GET           /summary/:formTemplateId4Ga/                                                                       uk.gov.hmrc.gform.gform.SummaryController.summaryById(f: FormId, formTemplateId4Ga: FormTemplateId4Ga, lang: Option[String])
 GET           /summary/pdf/:formTemplateId4Ga                                                                    uk.gov.hmrc.gform.gform.SummaryController.downloadPDF(f: FormId, formTemplateId4Ga: FormTemplateId4Ga, lang: Option[String])
 GET           /declaration/:formTemplateId4Ga                                                                    uk.gov.hmrc.gform.gform.DeclarationController.showDeclaration(f: FormId, formTemplateId4Ga: FormTemplateId4Ga, lang: Option[String])


### PR DESCRIPTION
I have provided a route & action for Save and Exit to delete existing form.  In the past there was a single GET route shared between a form button (in the Start journey) and a link in Save and Exit.  The interaction actually needs to be redesigned and this may be done as part of Agent work