### PR TITLE
GFC-575 Fix a summary date render unit test

### DIFF
--- a/test/uk/gov/hmrc/gform/models/helpers/Extractors.scala
+++ b/test/uk/gov/hmrc/gform/models/helpers/Extractors.scala
@@ -44,7 +44,7 @@ object Extractors {
       m <- hrefExtractor.findAllIn(h.body).matchData
     } yield m.group(1)
 
-  val dateR = "(\\d{2}) (\\w+) (\\d{4})".r.unanchored
+  val dateR = "(\\d{2})\\W+(\\w+)\\W+(\\d{4})".r.unanchored
 
   def extractDates(html: List[Html]): List[(String, String, String)] =
     for {


### PR DESCRIPTION
GFC-575 Fix a unit test, the date now contains multiple spaces of separation and newline characters.

Sorry @nubz , I found this cause and just fixed it.  I haven't addressed the rather opaque 

https://github.com/hmrc/gform-frontend/blob/1abeb4b0066c448c3a41c550752480ff92b75add/app/uk/gov/hmrc/gform/views/summary/snippets/date.scala.html#L33

which should perhaps be extracted from Twirl