### PR TITLE
GFC-634 - Continue with existing form should fast-forward

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/FormController.scala
+++ b/app/uk/gov/hmrc/gform/gform/FormController.scala
@@ -101,7 +101,7 @@ class FormController(
                   val fcIds = section
                     .expandSection(dataRaw)
                     .expandedFCs
-                    .flatMap(_.allIds)
+                    .flatMap(_.allIdsExceptInfoMessages)
 
                   val firstVisit = !fcIds.forall(dataRaw.isDefinedAt)
                   val stop = section.continueIf.contains(Stop) || firstVisit

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormComponent.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormComponent.scala
@@ -33,12 +33,20 @@ case class FormComponentSimple(fc: FormComponent) extends FormComponentWithCtx
 
 case class ExpandedFormComponent(expandedFC: List[FormComponent]) extends AnyVal {
   def allIds: List[FormComponentId] =
-    expandedFC.map {
+    expandedFC.flatMap {
       case fc @ IsDate(_)       => Date.fields(fc.id)
       case fc @ IsAddress(_)    => Address.fields(fc.id)
       case fc @ IsUkSortCode(_) => UkSortCode.fields(fc.id)
       case fc                   => List(fc.id)
-    }.flatten
+    }
+
+  def allInfoMessageId: List[FormComponentId] =
+    expandedFC.flatMap {
+      case fc @ IsInformationMessage(_) => List(fc.id)
+      case _                            => Nil
+    }
+
+  def allIdsExceptInfoMessages: Set[FormComponentId] = allIds.toSet -- allInfoMessageId.toSet
 }
 
 case class FormComponent(


### PR DESCRIPTION
Do not check InfoMessage component when determining where to stop fast forward