### PR TITLE
GFC-800: Wrapped result of displaySterling function in BigNumber 

### DIFF
--- a/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
+++ b/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
@@ -92,7 +92,7 @@ object Javascript {
          |};
          |function displaySterling(result) {
          |
-         |  return result < 0 ? result.replace("-", "-£") : '£' BigNumber(result).toFormat(2)
+         |  return result < 0 ? result.replace("-", "-£") : '£' + BigNumber(result).toFormat(2)
          |};
          |""".stripMargin
   }

--- a/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
+++ b/app/uk/gov/hmrc/gform/models/helpers/Javascript.scala
@@ -91,7 +91,8 @@ object Javascript {
          |  return BigNumber(a).times(BigNumber(b));
          |};
          |function displaySterling(result) {
-         |  return result < 0 ? result.replace("-", "-£") : '£' + result
+         |
+         |  return result < 0 ? result.replace("-", "-£") : '£' BigNumber(result).toFormat(2)
          |};
          |""".stripMargin
   }

--- a/app/uk/gov/hmrc/gform/submission/SubmissionRef.scala
+++ b/app/uk/gov/hmrc/gform/submission/SubmissionRef.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.gform.submission
 import java.math.BigInteger
 import java.security.MessageDigest
 
-import play.api.libs.json.{Format, JsString, OFormat}
+import play.api.libs.json.{ Format, JsString, OFormat }
 import uk.gov.hmrc.gform.sharedmodel.ValueClassFormat
 import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
 


### PR DESCRIPTION
Stops the error on the 'Bingo duty profits in the return period' page, ensuring the commas are in the right place and the decimal point appears. Need to clarify whether the rounding is acceptable. 