### PR TITLE
Refactoring FormController

### DIFF
--- a/app/uk/gov/hmrc/gform/auth/AuthService.scala
+++ b/app/uk/gov/hmrc/gform/auth/AuthService.scala
@@ -17,22 +17,18 @@
 package uk.gov.hmrc.gform.auth
 
 import cats.implicits._
-import play.api.mvc._
-import scala.concurrent.ExecutionContext
 import uk.gov.hmrc.auth.core.authorise._
 import uk.gov.hmrc.auth.core.{ AffinityGroup, AuthConnector => _, _ }
 import uk.gov.hmrc.gform.auth.models._
 import uk.gov.hmrc.gform.config.AppConfig
 import uk.gov.hmrc.gform.gform
 import uk.gov.hmrc.gform.gform.{ AuthContextPrepop, EeittService }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Enrolment => _, _ }
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.cache.client.NoSessionException
-import uk.gov.hmrc.play.HeaderCarrierConverter
-import uk.gov.hmrc.gform.submission.SubmissionRef
 import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Enrolment => _, _ }
+import uk.gov.hmrc.gform.submission.SubmissionRef
+import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 class AuthService(
   appConfig: AppConfig,
@@ -173,12 +169,6 @@ class AuthService(
           }
         case otherAuthResults => otherAuthResults.pure[Future]
       }
-
-  private def agentSubscribeUrl(requestUri: String): String = {
-    val continueUrl = java.net.URLEncoder.encode(requestUri, "UTF-8")
-    val baseUrl = appConfig.`agent-subscription-frontend-base-url`
-    s"$baseUrl/agent-subscription/check-business-type?continue=$continueUrl"
-  }
 
   private def ggAgentAuthorise(
     agentAccess: AgentAccess,

--- a/app/uk/gov/hmrc/gform/gform/FormController.scala
+++ b/app/uk/gov/hmrc/gform/gform/FormController.scala
@@ -21,7 +21,7 @@ import cats.instances.option._
 import cats.syntax.applicative._
 import cats.syntax.apply._
 import cats.syntax.eq._
-import cats.syntax.validated._
+import play.api.data
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.gform.auth.models.{ IsAgent, MaterialisedRetrievals }
@@ -30,22 +30,22 @@ import uk.gov.hmrc.gform.controllers._
 import uk.gov.hmrc.gform.controllers.helpers.FormDataHelpers.processResponseDataFromBody
 import uk.gov.hmrc.gform.controllers.helpers._
 import uk.gov.hmrc.gform.fileupload.{ Envelope, FileUploadService }
+import uk.gov.hmrc.gform.gform.handlers.{ FormControllerRequestHandler, NotToBeRedirected, ToBeRedirected }
 import uk.gov.hmrc.gform.gformbackend.GformConnector
 import uk.gov.hmrc.gform.graph.Data
-import uk.gov.hmrc.gform.models.{ AgentAccessCode, ProcessData, ProcessDataService }
 import uk.gov.hmrc.gform.models.ExpandUtils._
+import uk.gov.hmrc.gform.models.gform.FormValidationOutcome
+import uk.gov.hmrc.gform.models.{ AgentAccessCode, ProcessData, ProcessDataService }
 import uk.gov.hmrc.gform.obligation.ObligationService
 import uk.gov.hmrc.gform.sharedmodel._
 import uk.gov.hmrc.gform.sharedmodel.form._
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ UserId => _, _ }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.SectionTitle4Ga._
-import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
-import uk.gov.hmrc.gform.validation.{ FormFieldValidationResult, ValidationService }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ UserId => _, _ }
+import uk.gov.hmrc.gform.validation.ValidationService
 import uk.gov.hmrc.gform.views.html.form._
 import uk.gov.hmrc.gform.views.html.hardcoded.pages._
 import uk.gov.hmrc.http.{ HeaderCarrier, NotFoundException }
 import uk.gov.hmrc.play.frontend.controller.FrontendController
-import uk.gov.hmrc.gform.models.gform.{ FormComponentValidation, FormValidationOutcome }
 
 import scala.concurrent.Future
 
@@ -62,89 +62,30 @@ class FormController(
   gformConnector: GformConnector,
   processDataService: ProcessDataService[Future, Throwable],
   obligationService: ObligationService,
-  formService: FormService
+  formService: FormService,
+  handler: FormControllerRequestHandler
 ) extends FrontendController {
 
   import i18nSupport._
-  private def validateForm(
-    data: FormDataRecalculated,
-    sections: List[Section],
-    sn: SectionNumber,
-    cache: AuthCacheWithForm)(
-    implicit request: Request[AnyContent]
-  ): Future[FormValidationOutcome] =
-    validate(data, sections, sn, cache.form.envelopeId, cache.retrievals, cache.form.thirdPartyData, cache.formTemplate)
-      .map {
-        case (validationResult, validatedType, _) =>
-          val fcvs: List[FormComponentValidation] = validationResult.map {
-            case (formComponent, formFieldValidationResult) =>
-              FormComponentValidation(formComponent, formFieldValidationResult)
-          }
-          formService.extractedValidateFormHelper(fcvs, validatedType)
-      }
 
-  private def fastForwardValidate(processData: ProcessData, cache: AuthCacheWithForm)(
-    implicit request: Request[AnyContent]
-  ): Future[Option[SectionNumber]] = {
-
-    val sections = processData.sections
-    val data = processData.data
-
-    new Origin(sections, data).availableSectionNumbers.foldLeft(Future.successful(None: Option[SectionNumber])) {
-      case (accF, currentSn) =>
-        accF.flatMap { acc =>
-          acc match {
-            case Some(sn) => Future.successful(Some(sn))
-            case None =>
-              validateForm(data, sections, currentSn, cache).map {
-                case FormValidationOutcome(isValid, _, _) =>
-                  val section = sections(currentSn.value)
-                  val hasBeenVisited = processData.visitIndex.visitsIndex.contains(currentSn.value)
-
-                  val stop = section.continueIf.contains(Stop) || !hasBeenVisited
-                  if (isValid && !stop) None else Some(currentSn)
-              }
-          }
-        }
-    }
-  }
-
-  private def redirectOrigin(
-    maybeAccessCode: Option[AccessCode],
-    cache: AuthCacheWithForm,
-    processData: ProcessData,
-    lang: Option[String])(
-    implicit request: Request[AnyContent]
-  ): Future[Result] = {
-
-    val formTemplate = cache.formTemplate
-
-    fastForwardValidate(processData, cache).map {
-      case Some(sn) =>
-        val section = processData.sections(sn.value)
-        val sectionTitle4Ga = sectionTitle4GaFactory(section.title)
-        Redirect(
-          routes.FormController
-            .form(formTemplate._id, maybeAccessCode, sn, sectionTitle4Ga, lang, SeYes))
-      case None => Redirect(routes.SummaryController.summaryById(formTemplate._id, maybeAccessCode, lang))
-
-    }
-  }
+  implicit val frontendConfig: FrontendAppConfig = frontendAppConfig
 
   // TODO: this method should really be in the SignOutController which does not yet exist
   def keepAlive() = auth.keepAlive()
 
   def dashboard(formTemplateId: FormTemplateId, lang: Option[String]) = auth.async(formTemplateId, lang) {
     implicit request => cache =>
-      val formId = FormId(cache.retrievals, formTemplateId, None)
-      for {
-        maybeForm <- gformConnector.maybeForm(formId)
-      } yield
-        (cache.formTemplate.draftRetrievalMethod, cache.retrievals, maybeForm) match {
-          case (Some(FormAccessCodeForAgents), IsAgent(), None) =>
-            Ok(access_code_start(cache.formTemplate, AgentAccessCode.form, lang, frontendAppConfig))
-          case _ => Redirect(routes.FormController.newForm(formTemplateId, lang))
+      import cache._
+
+      val formId = FormId(retrievals, formTemplateId, None)
+
+      gformConnector.maybeForm(formId).map { form =>
+        handler.handleDashboard(formTemplate, retrievals, form) match {
+          case NotToBeRedirected(_) =>
+            Ok(access_code_start(formTemplate, AgentAccessCode.form, lang, frontendAppConfig))
+          case ToBeRedirected => Redirect(routes.FormController.newForm(formTemplateId, lang))
         }
+      }
   }
 
   def newFormAgent(formTemplateId: FormTemplateId, lang: Option[String]) = auth.async(formTemplateId, lang) {
@@ -157,15 +98,17 @@ class FormController(
           .flashing(AgentAccessCode.key -> accessCode.value)
   }
 
-  def showAccessCode(formTemplateId: FormTemplateId, lang: Option[String]) = auth.async(formTemplateId, lang) {
-    implicit request => cache =>
-      request.flash.get(AgentAccessCode.key) match {
-        case Some(accessCode) =>
-          Future.successful(
-            Ok(start_new_form(cache.formTemplate, AgentAccessCode(accessCode), lang, frontendAppConfig)))
-        case None => Future.successful(Redirect(routes.FormController.dashboard(formTemplateId, lang)))
+  def showAccessCode(formTemplateId: FormTemplateId, lang: Option[String]): Action[AnyContent] =
+    auth.async(formTemplateId, lang) { implicit request => cache =>
+      Future.successful {
+        val accessCode = request.flash.get(AgentAccessCode.key)
+        handler.handleAccessCode(accessCode) match {
+          case NotToBeRedirected(code) =>
+            Ok(start_new_form(cache.formTemplate, AgentAccessCode(code), lang, frontendAppConfig))
+          case ToBeRedirected => Redirect(routes.FormController.dashboard(formTemplateId, lang))
+        }
       }
-  }
+    }
 
   def newForm(formTemplateId: FormTemplateId, lang: Option[String]) = auth.async(formTemplateId, lang) {
     implicit request => cache =>
@@ -201,11 +144,36 @@ class FormController(
     cache: AuthCacheWithForm,
     dataRaw: Data,
     maybeAccessCode: Option[AccessCode],
-    lang: Option[String])(implicit request: Request[AnyContent]) =
+    lang: Option[String])(implicit request: Request[AnyContent]): Future[Result] =
     for {
       processData <- processDataService.getProcessData(dataRaw, cache)
-      res         <- redirectOrigin(maybeAccessCode, cache, processData, lang)
-    } yield res
+      maybeSectionNumber <- handler.handleRedirectOrigin(
+                             maybeAccessCode,
+                             cache,
+                             processData,
+                             lang,
+                             formService.extractedValidateFormHelper,
+                             fileUploadService.getEnvelope,
+                             validationService.validateFormComponents,
+                             validationService.evaluateValidation
+                           )
+    } yield redirectResult(cache, maybeAccessCode, lang, processData, maybeSectionNumber)
+
+  private def redirectResult(
+    cache: AuthCacheWithForm,
+    maybeAccessCode: Option[AccessCode],
+    lang: Option[String],
+    processData: ProcessData,
+    maybeSectionNumber: Option[SectionNumber]): Result =
+    maybeSectionNumber match {
+      case Some(sn) =>
+        val section = processData.sections(sn.value)
+        val sectionTitle4Ga = sectionTitle4GaFactory(section.title)
+        Redirect(
+          routes.FormController
+            .form(cache.formTemplate._id, maybeAccessCode, sn, sectionTitle4Ga, lang, SeYes))
+      case None => Redirect(routes.SummaryController.summaryById(cache.formTemplate._id, maybeAccessCode, lang))
+    }
 
   def newFormPost(formTemplateId: FormTemplateId, lang: Option[String]): Action[AnyContent] =
     auth.async(formTemplateId, lang) { implicit request => cache =>
@@ -244,7 +212,7 @@ class FormController(
       maybeForm <- gformConnector.maybeForm(formId)
       maybeFormExceptSubmitted = maybeForm.filter(_.status != Submitted)
       maybeEnvelope <- maybeFormExceptSubmitted.fold(Option.empty[Envelope].pure[Future]) { f =>
-                        getEnvelope(f.envelopeId)
+                        fileUploadService.getMaybeEnvelope(f.envelopeId)
                       }
       mayBeFormExceptWithEnvelope <- (maybeFormExceptSubmitted, maybeEnvelope) match {
                                       case (None, _)          => None.pure[Future]
@@ -252,12 +220,6 @@ class FormController(
                                       case (Some(_), Some(_)) => maybeFormExceptSubmitted.pure[Future]
                                     }
     } yield mayBeFormExceptWithEnvelope
-
-  private def getEnvelope(envelopeId: EnvelopeId)(implicit hc: HeaderCarrier): Future[Option[Envelope]] =
-    for {
-      maybeEnvelope <- fileUploadService.getMaybeEnvelope(envelopeId)
-      maybeFormExceptSubmitted = maybeEnvelope
-    } yield maybeFormExceptSubmitted
 
   private def startFreshForm(
     formTemplateId: FormTemplateId,
@@ -298,60 +260,43 @@ class FormController(
     sectionTitle4Ga: SectionTitle4Ga,
     lang: Option[String],
     suppressErrors: SuppressErrors) = auth.async(formTemplateId, lang, maybeAccessCode) { implicit request => cache =>
-    val formTemplate = cache.formTemplate
-    val envelopeId = cache.form.envelopeId
-    val retrievals = cache.retrievals
-    val obligations = cache.obligations
-    val dataRaw: Data = FormDataHelpers.formDataMap(cache.form.formData)
-
-    val visits: VisitIndex = cache.form.visitsIndex
-    val visitsIndex: VisitIndex = visits.visit(sectionNumber)
-
-    for {
-      update <- obligationService.updateObligations(
-                 cache.oldForm._id,
-                 UserData(
-                   cache.form.formData,
-                   cache.form.status,
-                   cache.form.visitsIndex,
-                   cache.form.thirdPartyData,
-                   cache.form.obligations
-                 ),
-                 cache.oldForm,
-                 cache.form
-               )
-      (data, sections) <- processDataService.recalculateDataAndSections(dataRaw, cache)
-      (errors, v, envelope) <- suppressErrors match {
-                                case SeYes => envelopeF(envelopeId).map((List.empty, ValidationResult.empty.valid, _))
-                                case SeNo =>
-                                  validate(
-                                    data,
-                                    sections,
-                                    sectionNumber,
-                                    envelopeId,
-                                    retrievals,
-                                    cache.form.thirdPartyData,
-                                    cache.formTemplate)
-                              }
-      html = renderer.renderSection(
+    handler
+      .handleForm(
+        formTemplateId,
         maybeAccessCode,
-        cache.form,
         sectionNumber,
-        data,
-        formTemplate,
-        errors,
-        envelope,
-        envelopeId,
-        v,
-        sections,
+        sectionTitle4Ga,
+        lang,
+        suppressErrors,
+        cache,
+        obligationService.updateObligations[Future],
+        processDataService.recalculateDataAndSections,
+        fileUploadService.getEnvelope,
+        renderer.renderSection,
         formMaxAttachmentSizeMB,
         contentTypes,
-        retrievals,
-        visitsIndex,
-        lang,
-        obligations
+        validationService.validateFormComponents,
+        validationService.evaluateValidation
       )
-    } yield Ok(html)
+      .map(handlerResult =>
+        Ok(renderer.renderSection(
+          maybeAccessCode,
+          cache.form,
+          sectionNumber,
+          handlerResult.data,
+          cache.formTemplate,
+          handlerResult.result,
+          handlerResult.envelope,
+          cache.form.envelopeId,
+          handlerResult.validatedType,
+          handlerResult.sections,
+          formMaxAttachmentSizeMB,
+          contentTypes,
+          cache.retrievals,
+          cache.form.visitsIndex.visit(sectionNumber),
+          lang,
+          cache.obligations
+        )))
   }
 
   def fileUploadPage(
@@ -384,7 +329,7 @@ class FormController(
     ).pure[Future]
   }
 
-  val choice = play.api.data.Form(
+  val choice: data.Form[String] = play.api.data.Form(
     play.api.data.Forms.single(
       "decision" -> play.api.data.Forms.nonEmptyText
     ))
@@ -436,33 +381,6 @@ class FormController(
 
   val deleteOnExit = delete _
 
-  def envelopeF(envelopeId: EnvelopeId)(implicit headerCarrier: HeaderCarrier): Future[Envelope] =
-    fileUploadService.getEnvelope(envelopeId)
-
-  def validate(
-    formDataRecalculated: FormDataRecalculated,
-    sections: List[Section],
-    sectionNumber: SectionNumber,
-    envelopeId: EnvelopeId,
-    retrievals: MaterialisedRetrievals,
-    thirdPartyData: ThirdPartyData,
-    formTemplate: FormTemplate
-  )(
-    implicit request: Request[AnyContent]
-  ): Future[(List[(FormComponent, FormFieldValidationResult)], ValidatedType[ValidationResult], Envelope)] = {
-    val section = sections(sectionNumber.value)
-    val nonSubmittedYet = nonSubmittedFCsOfNonGroup(formDataRecalculated, section)
-    val allFC = submittedFCs(formDataRecalculated, sections.flatMap(_.expandSection(formDataRecalculated.data).allFCs)) ++ nonSubmittedYet
-    val sectionFields = submittedFCs(formDataRecalculated, section.expandSection(formDataRecalculated.data).allFCs) ++ nonSubmittedYet
-
-    for {
-      envelope <- envelopeF(envelopeId)
-      v <- validationService
-            .validateForm(sectionFields, section, envelopeId, retrievals, thirdPartyData, formTemplate)(
-              formDataRecalculated)
-    } yield (validationService.evaluateValidation(v, allFC, formDataRecalculated, envelope), v, envelope)
-  }
-
   def updateFormData(
     formTemplateId: FormTemplateId,
     maybeAccessCode: Option[AccessCode],
@@ -475,11 +393,16 @@ class FormController(
       def validateAndUpdateData(cache: AuthCacheWithForm, processData: ProcessData)(
         toResult: Option[SectionNumber] => Result): Future[Result] =
         for {
-          FormValidationOutcome(_, formData, v) <- validateForm(
+          FormValidationOutcome(_, formData, v) <- handler.handleFormValidation(
                                                     processData.data,
                                                     processData.sections,
                                                     sectionNumber,
-                                                    cache)
+                                                    cache,
+                                                    formService.extractedValidateFormHelper,
+                                                    fileUploadService.getEnvelope,
+                                                    validationService.validateFormComponents,
+                                                    validationService.evaluateValidation
+                                                  )
           res <- {
             val before: ThirdPartyData = cache.form.thirdPartyData
             val after: ThirdPartyData = before.updateFrom(v)
@@ -504,7 +427,14 @@ class FormController(
       def updateUserData(cache: AuthCacheWithForm, processData: ProcessData)(
         toResult: Option[SectionNumber] => Result): Future[Result] =
         for {
-          maybeSn <- fastForwardValidate(processData, cache)
+          maybeSn <- handler.handleFastForwardValidate(
+                      processData,
+                      cache,
+                      formService.extractedValidateFormHelper,
+                      fileUploadService.getEnvelope,
+                      validationService.validateFormComponents,
+                      validationService.evaluateValidation
+                    )
           userData = UserData(
             cache.form.formData,
             maybeSn.fold(Summary: FormStatus)(_ => InProgress),
@@ -592,7 +522,6 @@ class FormController(
     }
   }
 
-  private lazy val firstSection = SectionNumber(0)
   private lazy val formMaxAttachmentSizeMB = appConfig.formMaxAttachmentSizeMB
   private lazy val contentTypes = appConfig.contentTypes
 }

--- a/app/uk/gov/hmrc/gform/gform/GformModule.scala
+++ b/app/uk/gov/hmrc/gform/gform/GformModule.scala
@@ -17,12 +17,14 @@
 package uk.gov.hmrc.gform.gform
 
 import cats.instances.future._
+
 import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.gform.auditing.AuditingModule
 import uk.gov.hmrc.gform.auth.{ AgentEnrolmentController, AuthModule, ErrorController }
 import uk.gov.hmrc.gform.config.ConfigModule
 import uk.gov.hmrc.gform.controllers.ControllersModule
 import uk.gov.hmrc.gform.fileupload.FileUploadModule
+import uk.gov.hmrc.gform.gform.handlers.{ FormControllerRequestHandler, FormValidator }
 import uk.gov.hmrc.gform.gformbackend.GformBackendModule
 import uk.gov.hmrc.gform.graph.GraphModule
 import uk.gov.hmrc.gform.models.ProcessDataService
@@ -78,7 +80,8 @@ class GformModule(
     gformBackendModule.gformConnector,
     processDataService,
     controllersModule.obligationService,
-    controllersModule.formService
+    controllersModule.formService,
+    new FormControllerRequestHandler(new FormValidator())
   )
 
   val summaryController: SummaryController = new SummaryController(

--- a/app/uk/gov/hmrc/gform/gform/handlers/FormControllerRequestHandler.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/FormControllerRequestHandler.scala
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.gform.handlers
+
+import cats.syntax.validated._
+import play.api.mvc.{ AnyContent, Request }
+import uk.gov.hmrc.gform.auth.models.{ IsAgent, MaterialisedRetrievals }
+import uk.gov.hmrc.gform.controllers.AuthCacheWithForm
+import uk.gov.hmrc.gform.controllers.helpers.FormDataHelpers
+import uk.gov.hmrc.gform.fileupload.Envelope
+import uk.gov.hmrc.gform.models.ProcessData
+import uk.gov.hmrc.gform.models.gform.{ FormComponentValidation, FormValidationOutcome }
+import uk.gov.hmrc.gform.sharedmodel.AccessCode
+import uk.gov.hmrc.gform.sharedmodel.config.ContentType
+import uk.gov.hmrc.gform.sharedmodel.form._
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormAccessCodeForAgents, FormComponent, FormTemplate, FormTemplateId, SeNo, SeYes, Section, SectionNumber, SectionTitle4Ga, SuppressErrors, UserId => _ }
+import uk.gov.hmrc.gform.validation.FormFieldValidationResult
+import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class FormControllerRequestHandler(formValidator: FormValidator)(implicit ec: ExecutionContext) {
+
+  def handleDashboard(
+    formTemplate: FormTemplate,
+    retrievals: MaterialisedRetrievals,
+    maybeForm: Option[Form]): Redirection[Unit] =
+    (formTemplate.draftRetrievalMethod, retrievals, maybeForm) match {
+      case (Some(FormAccessCodeForAgents), IsAgent(), None) => NotToBeRedirected(())
+      case _                                                => ToBeRedirected
+    }
+
+  def handleAccessCode(accessCode: Option[String]): Redirection[String] =
+    accessCode.fold[Redirection[String]](ToBeRedirected)(NotToBeRedirected(_))
+
+  def handleSuppressErrors(
+    sectionNumber: SectionNumber,
+    suppressErrors: SuppressErrors,
+    cache: AuthCacheWithForm,
+    envelopeId: EnvelopeId,
+    retrievals: MaterialisedRetrievals,
+    data: FormDataRecalculated,
+    sections: List[Section],
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation
+  )(implicit hc: HeaderCarrier, request: Request[AnyContent])
+    : Future[(List[(FormComponent, FormFieldValidationResult)], ValidatedType[ValidationResult], Envelope)] =
+    suppressErrors match {
+      case SeYes =>
+        envelopeF(envelopeId).map((List.empty, ValidationResult.empty.valid, _))
+      case SeNo =>
+        handleValidate(
+          data,
+          sections,
+          sectionNumber,
+          envelopeId,
+          retrievals,
+          cache.form.thirdPartyData,
+          cache.formTemplate,
+          envelopeF,
+          validateFormComponents,
+          evaluateValidation)
+    }
+
+  def handleForm(
+    formTemplateId: FormTemplateId,
+    maybeAccessCode: Option[AccessCode],
+    sectionNumber: SectionNumber,
+    sectionTitle4Ga: SectionTitle4Ga,
+    lang: Option[String],
+    suppressErrors: SuppressErrors,
+    cache: AuthCacheWithForm,
+    updateObligations: UpdateObligations[Future], //TODO remove all the Future
+    recalculateDataAndSections: RecalculateDataAndSections[Future],
+    envelopeF: EnvelopeId => Future[Envelope],
+    htmlGenerator: HtmlGenerator,
+    formMaxAttachmentSizeMB: Int,
+    contentTypes: List[ContentType],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation
+  )(implicit hc: HeaderCarrier, request: Request[AnyContent]): Future[FormHandlerResult] = {
+    val envelopeId = cache.form.envelopeId
+    val retrievals = cache.retrievals
+
+    for {
+      _ <- updateObligations(
+            cache.oldForm._id,
+            UserData(
+              cache.form.formData,
+              cache.form.status,
+              cache.form.visitsIndex,
+              cache.form.thirdPartyData,
+              cache.form.obligations),
+            cache.oldForm,
+            cache.form
+          )
+      (data, sections) <- recalculateDataAndSections(FormDataHelpers.formDataMap(cache.form.formData), cache)
+      (errors, validate, envelope) <- handleSuppressErrors(
+                                       sectionNumber,
+                                       suppressErrors,
+                                       cache,
+                                       envelopeId,
+                                       retrievals,
+                                       data,
+                                       sections,
+                                       envelopeF,
+                                       validateFormComponents,
+                                       evaluateValidation
+                                     )
+    } yield FormHandlerResult(data, errors, envelope, validate, sections)
+  }
+
+  def handleFormValidation(
+    data: FormDataRecalculated,
+    sections: List[Section],
+    sn: SectionNumber,
+    cache: AuthCacheWithForm,
+    extractedValidateFormHelper: (
+      List[FormComponentValidation],
+      ValidatedType[ValidationResult]) => FormValidationOutcome,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation
+  )(
+    implicit request: Request[AnyContent]
+  ): Future[FormValidationOutcome] =
+    formValidator.validateForm(
+      data,
+      sections,
+      sn,
+      cache,
+      extractedValidateFormHelper,
+      envelopeF,
+      validateFormComponents,
+      evaluateValidation)
+
+  def handleFastForwardValidate(
+    processData: ProcessData,
+    cache: AuthCacheWithForm,
+    extractedValidateFormHelper: (
+      List[FormComponentValidation],
+      ValidatedType[ValidationResult]) => FormValidationOutcome,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation)(
+    implicit request: Request[AnyContent]
+  ): Future[Option[SectionNumber]] =
+    formValidator.fastForwardValidate(
+      processData,
+      cache,
+      extractedValidateFormHelper,
+      envelopeF,
+      validateFormComponents,
+      evaluateValidation)
+
+  def handleValidate(
+    formDataRecalculated: FormDataRecalculated,
+    sections: List[Section],
+    sectionNumber: SectionNumber,
+    envelopeId: EnvelopeId,
+    retrievals: MaterialisedRetrievals,
+    thirdPartyData: ThirdPartyData,
+    formTemplate: FormTemplate,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation)(
+    implicit request: Request[AnyContent]
+  ): Future[(List[(FormComponent, FormFieldValidationResult)], ValidatedType[ValidationResult], Envelope)] =
+    formValidator.validate(
+      formDataRecalculated,
+      sections,
+      sectionNumber,
+      envelopeId,
+      retrievals,
+      thirdPartyData,
+      formTemplate,
+      envelopeF,
+      validateFormComponents,
+      evaluateValidation)
+
+  def handleRedirectOrigin(
+    maybeAccessCode: Option[AccessCode],
+    cache: AuthCacheWithForm,
+    processData: ProcessData,
+    lang: Option[String],
+    extractedValidateFormHelper: (
+      List[FormComponentValidation],
+      ValidatedType[ValidationResult]) => FormValidationOutcome,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation
+  )(
+    implicit request: Request[AnyContent]
+  ): Future[Option[SectionNumber]] =
+    handleFastForwardValidate(
+      processData,
+      cache,
+      extractedValidateFormHelper,
+      envelopeF,
+      validateFormComponents,
+      evaluateValidation
+    )
+}
+
+case class FormHandlerResult(
+  data: FormDataRecalculated,
+  result: List[(FormComponent, FormFieldValidationResult)],
+  envelope: Envelope,
+  validatedType: ValidatedType[ValidationResult],
+  sections: List[Section])

--- a/app/uk/gov/hmrc/gform/gform/handlers/FormValidator.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/FormValidator.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.gform.handlers
+
+import play.api.mvc.{ AnyContent, Request }
+import uk.gov.hmrc.gform.auth.models.MaterialisedRetrievals
+import uk.gov.hmrc.gform.controllers.{ AuthCacheWithForm, Origin }
+import uk.gov.hmrc.gform.fileupload.Envelope
+import uk.gov.hmrc.gform.models.ExpandUtils.{ nonSubmittedFCsOfNonGroup, submittedFCs }
+import uk.gov.hmrc.gform.models.ProcessData
+import uk.gov.hmrc.gform.models.gform.{ FormComponentValidation, FormValidationOutcome }
+import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, FormDataRecalculated, ThirdPartyData, ValidationResult }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.validation.FormFieldValidationResult
+import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class FormValidator(implicit ec: ExecutionContext) {
+
+  def validateForm(
+    data: FormDataRecalculated,
+    sections: List[Section],
+    sn: SectionNumber,
+    cache: AuthCacheWithForm,
+    extractedValidateFormHelper: (
+      List[FormComponentValidation],
+      ValidatedType[ValidationResult]) => FormValidationOutcome,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation
+  )(
+    implicit request: Request[AnyContent]
+  ): Future[FormValidationOutcome] =
+    validate(
+      data,
+      sections,
+      sn,
+      cache.form.envelopeId,
+      cache.retrievals,
+      cache.form.thirdPartyData,
+      cache.formTemplate,
+      envelopeF,
+      validateFormComponents,
+      evaluateValidation
+    ).map {
+      case (validationResult, validatedType, _) =>
+        val fcvs: List[FormComponentValidation] = validationResult.map {
+          case (formComponent, formFieldValidationResult) =>
+            FormComponentValidation(formComponent, formFieldValidationResult)
+        }
+        extractedValidateFormHelper(fcvs, validatedType)
+    }
+
+  def validate(
+    formDataRecalculated: FormDataRecalculated,
+    sections: List[Section],
+    sectionNumber: SectionNumber,
+    envelopeId: EnvelopeId,
+    retrievals: MaterialisedRetrievals,
+    thirdPartyData: ThirdPartyData,
+    formTemplate: FormTemplate,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation
+  )(
+    implicit request: Request[AnyContent]
+  ): Future[(List[(FormComponent, FormFieldValidationResult)], ValidatedType[ValidationResult], Envelope)] = {
+    val section = sections(sectionNumber.value)
+    val nonSubmittedYet = nonSubmittedFCsOfNonGroup(formDataRecalculated, section)
+    val allFC = submittedFCs(formDataRecalculated, sections.flatMap(_.expandSection(formDataRecalculated.data).allFCs)) ++ nonSubmittedYet
+    val sectionFields = submittedFCs(formDataRecalculated, section.expandSection(formDataRecalculated.data).allFCs) ++ nonSubmittedYet
+
+    for {
+      envelope <- envelopeF(envelopeId)
+      v <- validateFormComponents(
+            sectionFields,
+            section,
+            envelopeId,
+            retrievals,
+            thirdPartyData,
+            formTemplate,
+            formDataRecalculated)
+    } yield (evaluateValidation(v, allFC, formDataRecalculated, envelope), v, envelope)
+  }
+
+  def fastForwardValidate(
+    processData: ProcessData,
+    cache: AuthCacheWithForm,
+    extractedValidateFormHelper: (
+      List[FormComponentValidation],
+      ValidatedType[ValidationResult]) => FormValidationOutcome,
+    envelopeF: EnvelopeId => Future[Envelope],
+    validateFormComponents: ValidateFormComponents[Future],
+    evaluateValidation: EvaluateValidation)(
+    implicit request: Request[AnyContent]
+  ): Future[Option[SectionNumber]] = {
+
+    val sections = processData.sections
+    val data = processData.data
+
+    new Origin(sections, data).availableSectionNumbers.foldLeft(Future.successful(None: Option[SectionNumber])) {
+      case (accF, currentSn) =>
+        accF.flatMap {
+          case Some(sn) => Future.successful(Some(sn))
+          case None =>
+            validateForm(
+              data,
+              sections,
+              currentSn,
+              cache,
+              extractedValidateFormHelper,
+              envelopeF,
+              validateFormComponents,
+              evaluateValidation)
+              .map {
+                case FormValidationOutcome(isValid, _, _) =>
+                  val section = sections(currentSn.value)
+                  val hasBeenVisited = processData.visitIndex.visitsIndex.contains(currentSn.value)
+
+                  val stop = section.continueIf.contains(Stop) || !hasBeenVisited
+                  if (isValid && !stop) None else Some(currentSn)
+              }
+        }
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/gform/gform/handlers/Redirection.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/Redirection.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.gform.handlers
+
+sealed trait Redirection[+T]
+case object ToBeRedirected extends Redirection[Nothing]
+case class NotToBeRedirected[T](value: T) extends Redirection[T]

--- a/app/uk/gov/hmrc/gform/gform/handlers/package.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/package.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.gform
+
+import play.twirl.api.Html
+import uk.gov.hmrc.gform.auth.models.MaterialisedRetrievals
+import uk.gov.hmrc.gform.controllers.AuthCacheWithForm
+import uk.gov.hmrc.gform.fileupload.Envelope
+import uk.gov.hmrc.gform.graph.Data
+import uk.gov.hmrc.gform.sharedmodel.config.ContentType
+import uk.gov.hmrc.gform.sharedmodel.form._
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormComponent, FormTemplate, Section, SectionNumber }
+import uk.gov.hmrc.gform.sharedmodel.{ AccessCode, Obligations }
+import uk.gov.hmrc.gform.validation.FormFieldValidationResult
+import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
+
+package object handlers {
+
+  type HtmlGenerator = (
+    Option[AccessCode],
+    Form,
+    SectionNumber,
+    FormDataRecalculated,
+    FormTemplate,
+    List[(FormComponent, FormFieldValidationResult)],
+    Envelope,
+    EnvelopeId,
+    ValidatedType[ValidationResult],
+    List[Section],
+    Int,
+    List[ContentType],
+    MaterialisedRetrievals,
+    VisitIndex,
+    Option[String],
+    Obligations) => Html
+
+  type UpdateObligations[F[_]] = (FormId, UserData, Form, Form) => F[Unit]
+
+  type RecalculateDataAndSections[F[_]] = (Data, AuthCacheWithForm) => F[(FormDataRecalculated, List[Section])]
+
+  type ValidateForm[F[_]] = (
+    FormDataRecalculated,
+    List[Section],
+    SectionNumber,
+    EnvelopeId,
+    MaterialisedRetrievals,
+    ThirdPartyData,
+    FormTemplate) => F[(List[(FormComponent, FormFieldValidationResult)], ValidatedType[ValidationResult], Envelope)]
+
+  type ValidateFormComponents[F[_]] = (
+    List[FormComponent],
+    Section,
+    EnvelopeId,
+    MaterialisedRetrievals,
+    ThirdPartyData,
+    FormTemplate,
+    FormDataRecalculated) => F[ValidatedType[ValidationResult]]
+
+  type EvaluateValidation =
+    (
+      ValidatedType[ValidationResult],
+      List[FormComponent],
+      FormDataRecalculated,
+      Envelope) => List[(FormComponent, FormFieldValidationResult)]
+
+}

--- a/app/uk/gov/hmrc/gform/obligation/ObligationService.scala
+++ b/app/uk/gov/hmrc/gform/obligation/ObligationService.scala
@@ -157,12 +157,15 @@ class ObligationService(gformConnector: GformConnector) {
                  Future.successful(form)
     } yield output
 
-  def updateObligations(formId: FormId, userData: UserData, form: Form, newForm: Form)(
+  import cats.Monad
+
+  def updateObligations[F[_]](formId: FormId, userData: UserData, form: Form, newForm: Form)(
     implicit hc: HeaderCarrier,
-    ec: ExecutionContext) =
+    ec: ExecutionContext,
+    F: Monad[F]): F[Unit] =
     if (form.obligations != newForm.obligations) {
-      gformConnector.updateUserData(formId, userData)
+      F.pure(gformConnector.updateUserData(formId, userData).onComplete { case _ => () })
     } else {
-      Future.successful(())
+      F.pure(())
     }
 }

--- a/app/uk/gov/hmrc/gform/validation/ValidationService.scala
+++ b/app/uk/gov/hmrc/gform/validation/ValidationService.scala
@@ -80,14 +80,14 @@ class ValidationService(
       .getOrElse(ValidationResult.empty.valid.pure[Future])
   }
 
-  def validateForm(
+  def validateFormComponents(
     sectionFields: List[FormComponent],
     section: Section,
     envelopeId: EnvelopeId,
     retrievals: MaterialisedRetrievals,
     thirdPartyData: ThirdPartyData,
-    formTemplate: FormTemplate)(data: FormDataRecalculated)(
-    implicit hc: HeaderCarrier): Future[ValidatedType[ValidationResult]] = {
+    formTemplate: FormTemplate,
+    data: FormDataRecalculated)(implicit hc: HeaderCarrier): Future[ValidatedType[ValidationResult]] = {
     val eT = for {
       _ <- EitherT(
             validateComponents(sectionFields, data, envelopeId, retrievals, thirdPartyData, formTemplate).map(


### PR DESCRIPTION
Remove Future from handler

refactoring => inline few variables

refactoring => extract in to smaller functions step#1

refactoring => generic Monad on updateObligations

Extract more login in to request handler

revert monadless

Extract Html genration from controller

Extract obligations from controller

Extract recalculateDataAndSections from controller

Extract from controller spet#3

form handler wiring

Extract validation form

remove envelopeF fn

remove validate from controller

remove fast forward validation from controller

remove some redundant code

some cleaning up

extract redirect origin

remove implicit global

removing play from request handler

removing play from request handler step#2

removing play from request handler step#3

removing play from request handler step#4