### PR TITLE
GFORMS-628 - Ensure that destinations.customerId trimmed to 64 chars …

### DIFF
--- a/app/uk/gov/hmrc/gform/graph/CustomerIdRecalculation.scala
+++ b/app/uk/gov/hmrc/gform/graph/CustomerIdRecalculation.scala
@@ -68,6 +68,6 @@ class CustomerIdRecalculation[F[_]: Monad](
       case Constant(value) => value.pure[F]
 
       case _ => "".pure[F] //TODO change this to AuthExpr.
-    }).map(CustomerId(_))
+    }).map(customerId => CustomerId(customerId.take(64)))
 
 }


### PR DESCRIPTION
…where required