### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -38,13 +38,6 @@ google-tag-manager.id = "GTM-TSFTCWZ"
 # If you deploy your application to several instances be sure to use the same key!
 #play.crypto.secret="xmp46QiSN1xrRmdzUWsM6HFBXqgN5EEoDtL4PUMDSClBcdezLTOuKAZOEVTGj41T"
 
-#TODO: once updated to play 2.6.0 we should selectively configure csfr nocheck.
-# Read https://www.playframework.com/documentation/2.6.x/Highlights26#route-modifier-tags
-play.filters.csrf.header.bypassHeaders {
-  X-Requested-With = "*"
-  Csrf-Token = "nocheck"
-}
-
 controllers {
   uk.gov.hmrc.play.health.HealthController = {
     needsAuth = false


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051