### PR TITLE
GFORMS-1517 - Add a property to limit the number of items that can be…

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -295,7 +295,7 @@ class SectionRenderingService(
         limit.field match {
           case info @ IsInformationMessage(InformationMessage(infoType, infoText)) =>
             maybeMax.map { maxRepeatsBigDecimal =>
-              if (maxRepeatsBigDecimal.toInt === bracket.iterations.size) {
+              if (maxRepeatsBigDecimal.toInt <= bracket.iterations.size) {
                 AddToListLimitReached.Yes(
                   HtmlFormat.fill(
                     List(


### PR DESCRIPTION
… added in Add to List

When ATL limit depends on a field and its value changes down it can
happens that there is more iterations than maxRepaets limit, so '===' would not
catch that