### PR TITLE
GFORMS-1614 - Accessibility Testing-Attribute “name” not allowed on e…

### DIFF
--- a/app/uk/gov/hmrc/gform/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/gform/views/govuk_wrapper.scala.html
@@ -105,9 +105,10 @@
             "genericCharacterRemaining": "@{messages("generic.characterRemaining")}",
             "genericCharacterTooMany": "@{messages("generic.characterTooMany")}"
           }
-
-          @{timeoutDialog.fold(HtmlFormat.empty)(timeoutDialog => hmrcTimeoutDialog(timeoutDialog))}
     </script>
+
+   @{timeoutDialog.fold(HtmlFormat.empty)(timeoutDialog => hmrcTimeoutDialog(timeoutDialog))}
+
     <meta name="format-detection" content="telephone=no" />
 }
 


### PR DESCRIPTION
…lement “meta” and Element “meta” is missing one or more of the following attributes: “itemprop”, “property”.