### PR TITLE
GFORMS-1806 - Incorrect error message while uploading the invalid fil…

### DIFF
--- a/app/uk/gov/hmrc/gform/upscan/UpscanCallback.scala
+++ b/app/uk/gov/hmrc/gform/upscan/UpscanCallback.scala
@@ -96,6 +96,7 @@ sealed trait UpscanValidationFailure extends Product with Serializable {
   def toJsCode: String = this match {
     case UpscanValidationFailure.EntityTooLarge        => "EntityTooLarge"
     case UpscanValidationFailure.EntityTooSmall        => "EntityTooSmall"
+    case UpscanValidationFailure.Reject(_, _)          => "REJECT"
     case UpscanValidationFailure.InvalidFileType(_, _) => "InvalidFileType"
   }
 }
@@ -103,6 +104,7 @@ sealed trait UpscanValidationFailure extends Product with Serializable {
 object UpscanValidationFailure {
   case object EntityTooLarge extends UpscanValidationFailure
   case object EntityTooSmall extends UpscanValidationFailure
+  case class Reject(errorDetail: String, fileMimeType: ContentType) extends UpscanValidationFailure
   case class InvalidFileType(errorDetail: String, fileMimeType: ContentType) extends UpscanValidationFailure
 
   implicit val reads: Reads[UpscanValidationFailure] = derived.reads()

--- a/app/uk/gov/hmrc/gform/upscan/UpscanController.scala
+++ b/app/uk/gov/hmrc/gform/upscan/UpscanController.scala
@@ -101,6 +101,12 @@ class UpscanController(
                         FileInfoConfig.reverseLookup.getOrElse(fileMimeType, "").toUpperCase,
                         cache.formTemplate.allowedFileTypes.fileExtensions.toList.map(_.toUpperCase).mkString(", ")
                       )
+                    case ConfirmationFailure.GformValidationFailure(UpscanValidationFailure.Reject(_, _)) =>
+                      mkFlash(
+                        "file.error.type",
+                        "",
+                        cache.formTemplate.allowedFileTypes.fileExtensions.toList.map(_.toUpperCase).mkString(", ")
+                      )
                     case _ => mkFlash("file.error.upload.one.only")
                   }
 


### PR DESCRIPTION
…e types

- The upscan returns the below error while uploading the invalid file types

`Upscan failed - status: Failed, failureReason: UpscanFailure(FailureDetails(REJECTED,MIME type [image/png] is not allowed for service: [gform-frontend]))`