### PR TITLE
GFORMS-1930: TaskList Final and NonFinal CYA pages

### DIFF
--- a/app/uk/gov/hmrc/gform/binders/ValueClassBinder.scala
+++ b/app/uk/gov/hmrc/gform/binders/ValueClassBinder.scala
@@ -228,15 +228,18 @@ object ValueClassBinder {
 
       private val cyaPat1 = raw"cya([\d,]+)".r
       private val cyaPat2 = raw"cya([\d,]+)\.([\d,]+)".r
+      private val cyaPat3 = raw"cya([\d,]+)n".r
       override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, FastForward]] =
         params.get(key).flatMap(_.headOption).map {
           case FastForward.ffYes => FastForward.Yes.asRight
-          case cyaPat1(strSn)    => toSectionNumber(key, strSn).map(FastForward.CYA(_, None))
+          case cyaPat1(strSn)    => toSectionNumber(key, strSn).map(FastForward.CYA(_, SectionOrSummary.FormSummary))
+          case cyaPat3(strSn) =>
+            toSectionNumber(key, strSn).map(FastForward.CYA(_, SectionOrSummary.TaskSummary))
           case cyaPat2(to, from) =>
             for {
               sn1 <- toSectionNumber(key, to)
               sn2 <- toSectionNumber(key, from)
-            } yield FastForward.CYA(sn1, Some(sn2))
+            } yield FastForward.CYA(sn1, SectionOrSummary.Section(sn2))
           case value => toSectionNumber(key, value).map(FastForward.StopAt(_))
         }
 

--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -176,7 +176,7 @@ class SectionRenderingService(
               envelope,
               addressRecordLookup,
               None,
-              Some(FastForward.CYA(singletonWithNumber.sectionNumber, Some(sectionNumber)))
+              Some(FastForward.CYA(singletonWithNumber.sectionNumber, SectionOrSummary.Section(sectionNumber)))
             )
         }
     }
@@ -1286,7 +1286,7 @@ class SectionRenderingService(
                   ei.envelope,
                   ei.addressRecordLookup,
                   None,
-                  Some(FastForward.CYA(sn, Some(ei.sectionNumber)))
+                  Some(FastForward.CYA(sn, SectionOrSummary.Section(ei.sectionNumber)))
                 )
             }
             .toList

--- a/app/uk/gov/hmrc/gform/gform/handlers/FormControllerRequestHandler.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/FormControllerRequestHandler.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ SectionNumber, SuppressError
 import uk.gov.hmrc.gform.validation.ValidationResult
 
 import scala.concurrent.{ ExecutionContext, Future }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.SectionOrSummary
 
 class FormControllerRequestHandler(formValidator: FormValidator)(implicit ec: ExecutionContext) {
 
@@ -73,7 +74,7 @@ class FormControllerRequestHandler(formValidator: FormValidator)(implicit ec: Ex
     validatePageModel: ValidatePageModel[Future, DataOrigin.Browser],
     fastForward: FastForward,
     maybeCoordinates: Option[Coordinates]
-  ): Future[Option[SectionNumber]] =
+  ): Future[SectionOrSummary] =
     formValidator.fastForwardValidate(
       processData,
       cache,

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/SectionOrSummary.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/SectionOrSummary.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.sharedmodel.formtemplate
+
+sealed trait SectionOrSummary extends Product with Serializable
+
+object SectionOrSummary {
+  case class Section(sectionNumber: SectionNumber) extends SectionOrSummary
+  case object FormSummary extends SectionOrSummary
+  case object TaskSummary extends SectionOrSummary
+}

--- a/app/uk/gov/hmrc/gform/summary/SummaryRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/summary/SummaryRenderingService.scala
@@ -416,6 +416,11 @@ object SummaryRenderingService {
           begin_addToList_section(pageTitle)
       }
 
+      val ff = if (maybeCoordinates.isEmpty) {
+        FastForward.CYA(sectionNumber)
+      } else {
+        FastForward.CYA(sectionNumber, SectionOrSummary.TaskSummary)
+      }
       val middleRows: List[SummaryListRow] = page.fields
         .filterNot(_.hideOnSummary)
         .flatMap(formComponent =>
@@ -432,7 +437,7 @@ object SummaryRenderingService {
             envelope,
             addressRecordLookup,
             iterationTitle,
-            None
+            Some(ff)
           )
         )
 
@@ -477,6 +482,11 @@ object SummaryRenderingService {
 
       val sectionTitle4Ga: SectionTitle4Ga = sectionTitle4GaFactory(repeater, sectionNumber)
 
+      val ff = if (maybeCoordinates.isEmpty) {
+        FastForward.CYA(sectionNumber)
+      } else {
+        FastForward.CYA(sectionNumber, SectionOrSummary.TaskSummary)
+      }
       val url: Call = routes.FormController
         .form(
           formTemplate._id,
@@ -484,7 +494,7 @@ object SummaryRenderingService {
           sectionNumber,
           sectionTitle4Ga,
           SuppressErrors.Yes,
-          FastForward.CYA(sectionNumber)
+          ff
         )
 
       val addToListSummaryItems: List[Html] = addToListItemSummaries.map(ss => markDownParser(ss)).toList


### PR DESCRIPTION
Currently `FastForward.CYA(to: SectionNumber, from: Option[SectionNumber])` assumes that if from is `None` the destination is final CYA page. I refactored to use `Either[CYA.Summary, SectionNumber]` instead of option so that we can have 2 types of CYA pages - one is final and another one is CYA of the task.