### PR TITLE
GFORMS-1966 - Change behaviour of back link

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/FormController.scala
+++ b/app/uk/gov/hmrc/gform/gform/FormController.scala
@@ -255,7 +255,7 @@ class FormController(
                               cache.formTemplateWithRedirects.specimenSource,
                               handlerResult.validationResult,
                               cache.retrievals,
-                              fastForward
+                              FastForward.Yes
                             )
                           ).pure[Future]
                         )


### PR DESCRIPTION
The change link on ATL items page should be `FastForward.Yes`