### PR TITLE
GFORMS-1972: Update ATL so that first item always has a remove link

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/processor/FormProcessor.scala
+++ b/app/uk/gov/hmrc/gform/gform/processor/FormProcessor.scala
@@ -177,7 +177,7 @@ class FormProcessor(
         val pageIdToRemove = updFormModel.brackets.addToListBracket(addToListId).source.pageIdToDisplayAfterRemove
         val pageIdSectionNumberMap = updFormModel.pageIdSectionNumberMap
         val sectionNumber =
-          if (isLastIteration && pageIdToRemove.isDefined) {
+          if (isLastIteration) {
             pageIdToRemove.fold(
               maybeSectionNumber match {
                 case SectionOrSummary.Section(s) => addToListBracket.iterationForSectionNumber(s).firstSectionNumber

--- a/app/uk/gov/hmrc/gform/views/form/addToList.scala.html
+++ b/app/uk/gov/hmrc/gform/views/form/addToList.scala.html
@@ -108,12 +108,10 @@
               </a>
             </dd>
             <dd class="hmrc-add-to-a-list__remove">
-              @if(bracket.source.defaultPage.isDefined) {
-                <a class="govuk-link remove-add-to-list" aria-label='@messages("addToList.remove.visually.hidden", record.summaryText)' href="@{uk.gov.hmrc.gform.gform.routes.FormAddToListController.requestRemoval(formTemplate._id, maybeAccessCode, sectionNumber, record.index, AddToListId(bracket.source.id.formComponentId))}">
-                  <span aria-hidden="true">@messages("addToList.remove")</span>
-                  <span class="govuk-visually-hidden">@messages("addToList.remove.visually.hidden", record.summaryText)</span>
-                </a>
-              }
+              <a class="govuk-link remove-add-to-list" aria-label='@messages("addToList.remove.visually.hidden", record.summaryText)' href="@{uk.gov.hmrc.gform.gform.routes.FormAddToListController.requestRemoval(formTemplate._id, maybeAccessCode, sectionNumber, record.index, AddToListId(bracket.source.id.formComponentId))}">
+                <span aria-hidden="true">@messages("addToList.remove")</span>
+                <span class="govuk-visually-hidden">@messages("addToList.remove.visually.hidden", record.summaryText)</span>
+              </a>
             </dd>
           </div>
 	}


### PR DESCRIPTION
fix bugs:
- "Remove" button was missing for all items on repeater page
- After removing last page it jumped to the repeater page instead of the first page or the first iteration