### PR TITLE
GFORMS-1985 - Fix issue where clicking the back link goes to url with…

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/processor/FormProcessor.scala
+++ b/app/uk/gov/hmrc/gform/gform/processor/FormProcessor.scala
@@ -128,13 +128,13 @@ class FormProcessor(
             .map(_.sectionNumber)
             .toList ++ iterationForSectionNumber.checkYourAnswers.map(_.sectionNumber)
 
-          val toBeRemoved = visitsIndexForLastIteration.map(_.unsafeToClassic.sectionNumber)
-
-          visitsIndex.fold[VisitIndex](classic =>
+          visitsIndex.fold[VisitIndex] { classic =>
+            val toBeRemoved = visitsIndexForLastIteration.map(_.unsafeToClassic.sectionNumber)
             VisitIndex.Classic(
               classic.visitsIndex -- toBeRemoved
             )
-          ) { taskList =>
+          } { taskList =>
+            val toBeRemoved = visitsIndexForLastIteration.map(_.unsafeToTaskList.sectionNumber)
             val coordinates = sn.toCoordinatesUnsafe
 
             val indexes =


### PR DESCRIPTION
**Issue:** When I try to remove the last iteration of ATL with task-list, it raises `ava.lang.Exception: unsafeToClassic invoked on TaskList type: TaskList(Coordinates(TaskSectionNumber(3),TaskNumber(0)),0)` error