### PR TITLE
GFORMS-1967 - Update interface for upload of files

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -2733,7 +2733,7 @@ class SectionRenderingService(
 
     val uploadedFiles: Html = html.form.snippets.uploaded_files_wrapper(formComponent.id)(HtmlFormat.empty)
 
-    HtmlFormat.fill(fileInput :: uploadedFiles :: snippets)
+    HtmlFormat.fill(snippets ++ List(fileInput, uploadedFiles))
   }
 
   private def htmlForGroup(


### PR DESCRIPTION
The 'file' field must be the last field in the submitted form.