### PR TITLE
GFORMS-1997: fix file-upload fast forward bug

### DIFF
--- a/app/uk/gov/hmrc/gform/addresslookup/AddressLookupController.scala
+++ b/app/uk/gov/hmrc/gform/addresslookup/AddressLookupController.scala
@@ -402,7 +402,13 @@ class AddressLookupController(
               None
             ) // TODO JoVl Revisit maybeCoordinates param
         ) { sn =>
-          fastForwardService.redirectStopAt[SectionSelectorType.Normal](sn, cache, maybeAccessCode, formModelOptics)
+          fastForwardService.redirectStopAt[SectionSelectorType.Normal](
+            sn,
+            cache,
+            maybeAccessCode,
+            formModelOptics,
+            List(FastForward.StopAt(sn, false))
+          )
         }
 
     }

--- a/app/uk/gov/hmrc/gform/binders/ValueClassBinder.scala
+++ b/app/uk/gov/hmrc/gform/binders/ValueClassBinder.scala
@@ -236,7 +236,10 @@ object ValueClassBinder {
             for {
               sn2 <- toSectionNumber(key, from)
             } yield FastForward.CYA(SectionOrSummary.Section(sn2))
-          case value => toSectionNumber(key, value).map(FastForward.StopAt(_))
+          case value =>
+            val (f, v) = value.partition(_.toString == FastForward.ffStopAtForce)
+            val force = "$f" == FastForward.ffStopAtForce
+            toSectionNumber(key, v).map(FastForward.StopAt(_, force))
         }
 
       override def unbind(key: String, fastForward: FastForward): String =

--- a/app/uk/gov/hmrc/gform/fileupload/FileUploadController.scala
+++ b/app/uk/gov/hmrc/gform/fileupload/FileUploadController.scala
@@ -97,7 +97,8 @@ class FileUploadController(
                      sectionNumber,
                      cacheUpd,
                      maybeAccessCode,
-                     formModelOptics
+                     formModelOptics,
+                     List(FastForward.StopAt(sectionNumber, true))
                    )
         } yield res.flashing(flash)
 
@@ -217,7 +218,13 @@ class FileUploadController(
         }
 
         fastForwardService
-          .redirectStopAt[SectionSelectorType.Normal](sectionNumber, cache, maybeAccessCode, formModelOptics)
+          .redirectStopAt[SectionSelectorType.Normal](
+            sectionNumber,
+            cache,
+            maybeAccessCode,
+            formModelOptics,
+            List(FastForward.StopAt(sectionNumber))
+          )
           .map(_.flashing(flashWithFileId(flash, fileId)))
     }
 

--- a/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
+++ b/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
@@ -70,7 +70,8 @@ class FastForwardService(
     sectionNumber: SectionNumber,
     cache: AuthCacheWithForm,
     maybeAccessCode: Option[AccessCode],
-    formModelOptics: FormModelOptics[DataOrigin.Mongo]
+    formModelOptics: FormModelOptics[DataOrigin.Mongo],
+    fastForward: List[FastForward]
   )(implicit
     messages: Messages,
     hc: HeaderCarrier,
@@ -79,7 +80,7 @@ class FastForwardService(
     redirectWithRecalculation(
       cache,
       maybeAccessCode,
-      List(FastForward.StopAt(sectionNumber)),
+      fastForward,
       formModelOptics,
       Some(sectionNumber)
     )

--- a/app/uk/gov/hmrc/gform/gform/FormController.scala
+++ b/app/uk/gov/hmrc/gform/gform/FormController.scala
@@ -384,7 +384,7 @@ class FormController(
                   createBackUrl(toSectionNumber, fastForward),
                   Some(to)
                 )
-              case Some(FastForward.StopAt(sn)) =>
+              case Some(FastForward.StopAt(sn, _)) =>
                 sectionNumber.fold { classic =>
                   createBackUrl(toSectionNumber, FastForward.StopAt(sectionNumber) :: fastForward).pure[Future]
                 } { taskList =>
@@ -933,7 +933,7 @@ class FormController(
     val ff = rawFastForward
       .filterNot {
         case FastForward.CYA(SectionOrSummary.Section(sn)) => sectionNumber >= sn
-        case FastForward.StopAt(sn)                        => sectionNumber >= sn
+        case FastForward.StopAt(sn, _)                     => sectionNumber >= sn
         case _                                             => false
       }
     removeDuplications(ff)

--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -174,10 +174,10 @@ class SectionRenderingService(
         })(_.value)
 
     val ff = fastForward match {
-      case Nil                                     => Nil
-      case FastForward.CYA(to) :: xs               => FastForward.CYA(to) :: xs
-      case FastForward.StopAt(sectionNumber) :: xs => FastForward.StopAt(sectionNumber.increment) :: xs
-      case otherwise                               => otherwise
+      case Nil                                        => Nil
+      case FastForward.CYA(to) :: xs                  => FastForward.CYA(to) :: xs
+      case FastForward.StopAt(sectionNumber, _) :: xs => FastForward.StopAt(sectionNumber.increment) :: xs
+      case otherwise                                  => otherwise
     }
     html.form.addToListCheckYourAnswers(
       title,

--- a/app/uk/gov/hmrc/gform/gform/handlers/FormValidator.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/FormValidator.scala
@@ -190,8 +190,8 @@ class FormValidator(implicit ec: ExecutionContext) {
             case (Some(yesTo), SectionOrSummary.Section(cyaTo), _) => SectionOrSummary.Section(cyaTo)
           }
         )
-      case FastForward.StopAt(to) :: xs =>
-        val maxTo = nextFrom.fold(to)(n => List(to, n).max)
+      case FastForward.StopAt(to, force) :: xs =>
+        val maxTo = if (force) to else nextFrom.fold(to)(n => List(to, n).max)
         ffYesSnF.map {
           case None =>
             if (availableSectionNumbers.contains(maxTo)) {

--- a/app/uk/gov/hmrc/gform/models/FastForward.scala
+++ b/app/uk/gov/hmrc/gform/models/FastForward.scala
@@ -34,7 +34,10 @@ sealed trait FastForward extends Product with Serializable {
     }
 
   def asString: String =
-    fold(_ => FastForward.ffYes)(_.stopAt.value.toString) {
+    fold(_ => FastForward.ffYes) {
+      case FastForward.StopAt(v, false) => v.value.toString
+      case FastForward.StopAt(v, true)  => v.value.toString + FastForward.ffStopAtForce
+    } {
       case FastForward.CYA(SectionOrSummary.FormSummary) => FastForward.ffCYAFormSummary
       case FastForward.CYA(SectionOrSummary.TaskSummary) => FastForward.ffCYATaskSummary
       case FastForward.CYA(SectionOrSummary.Section(to)) =>
@@ -67,13 +70,14 @@ sealed trait FastForward extends Product with Serializable {
 object FastForward {
 
   case object Yes extends FastForward
-  case class StopAt(stopAt: SectionNumber) extends FastForward
+  case class StopAt(stopAt: SectionNumber, force: Boolean = false) extends FastForward
   case class CYA(to: SectionOrSummary = SectionOrSummary.FormSummary) extends FastForward
 
   val ffYes = "t"
   val ffCYAFormSummary = "cyaf"
   val ffCYATaskSummary = "cyat"
   val ffCYA = "cya"
+  val ffStopAtForce = "f"
 
   implicit val equal: Eq[FastForward] = Eq.fromUniversalEquals
 

--- a/app/uk/gov/hmrc/gform/upscan/UpscanController.scala
+++ b/app/uk/gov/hmrc/gform/upscan/UpscanController.scala
@@ -34,6 +34,7 @@ import uk.gov.hmrc.gform.sharedmodel.form.{ FileId, FormIdData }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormComponentId, FormTemplateId, SectionNumber }
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import uk.gov.hmrc.gform.eval.smartstring.SmartStringEvaluationSyntax
+import uk.gov.hmrc.gform.models.FastForward
 
 class UpscanController(
   auth: AuthenticatedRequestActions,
@@ -76,7 +77,8 @@ class UpscanController(
                         sectionNumber,
                         cache.copy(form = form),
                         maybeAccessCode,
-                        formModelOptics
+                        formModelOptics,
+                        List(FastForward.StopAt(sectionNumber, false))
                       )
                   }
                 case UpscanFileStatus.Failed =>
@@ -111,7 +113,13 @@ class UpscanController(
                   }
 
                   fastForwardService
-                    .redirectStopAt[SectionSelectorType.Normal](sectionNumber, cache, maybeAccessCode, formModelOptics)
+                    .redirectStopAt[SectionSelectorType.Normal](
+                      sectionNumber,
+                      cache,
+                      maybeAccessCode,
+                      formModelOptics,
+                      List(FastForward.StopAt(sectionNumber, false))
+                    )
                     .map(_.flashing(flashWithFileId(flash, fileId)))
               }
             }
@@ -187,7 +195,13 @@ class UpscanController(
         }
 
         fastForwardService
-          .redirectStopAt[SectionSelectorType.Normal](sectionNumber, cache, maybeAccessCode, formModelOptics)
+          .redirectStopAt[SectionSelectorType.Normal](
+            sectionNumber,
+            cache,
+            maybeAccessCode,
+            formModelOptics,
+            List(FastForward.StopAt(sectionNumber, false))
+          )
           .map(_.flashing(flashWithFileId(flash, fileId)))
     }
 


### PR DESCRIPTION
the fix adds a `force` flag to FastForward.StopAt
`StopAt` can sometimes be overridden (for example when it points to the current section). However for file-upload confirmation it does make sense. So when the `strict` flag is `true` the possible override is ignored. 