### PR TITLE
GFORMS-2062: keep in sync TimeoutDialog timeout and session.timeout

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,6 +171,8 @@ feature {
   concurrentAgentAccess = false
 }
 
+# Please keep this value the same as auth-module.timeout
+session.timeoutSeconds = 900
 auth-module {
   hmrc = {
     timeoutEnabled = true

--- a/public/javascripts/gformSessionTimeout.js
+++ b/public/javascripts/gformSessionTimeout.js
@@ -19,6 +19,7 @@
         channel.postMessage({
           timestamp: Date.now()
         });
+        $.ajax({url: "/submissions/keep-alive", type: "GET"});
       }
       return true;
     }


### PR DESCRIPTION
we should update session's timestamp when we post message to a "message-activity" channel. 
If we don't do that the first request /submissions/keep-alive from the dialog if not withing session.timeout will wipe out the session auth header and the next "Save and Continue" will redirect to the auth login.