### PR TITLE
GFORMS-2055 - When a form uses a format that has hint text in design …

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -2413,7 +2413,7 @@ class SectionRenderingService(
     )
 
     val filterHint: Hint = Hint(
-      content = content.Text(messages("postcodeLookup.Filter.hintText"))
+      content = content.Text(messages("postcodeLookup.Filter.hint"))
     )
 
     val attributes =


### PR DESCRIPTION
…system then form should use hint text by default