### PR TITLE
GFORMS-2303: The 'errors-html' and 'errors-html-usage' reports are re…

### DIFF
--- a/app/uk/gov/hmrc/gform/validation/DateChecker.scala
+++ b/app/uk/gov/hmrc/gform/validation/DateChecker.scala
@@ -441,7 +441,7 @@ class DateChecker[D <: DataOrigin]() extends ComponentChecker[Unit, D] {
     val dateProgram = (day, month, year)
       .mapN((d, m, y) => (d, m, y))
       .toProgram(
-        errorProgram = validationFailed[(String, String, String)](formComponent, "date.isMissing", None)
+        errorProgram = successProgram(("", "", ""))
       )
 
     dateProgram


### PR DESCRIPTION
…porting date errors that no longer happen