### PR TITLE
GFORMS-2562 - The address-lookup service returns a bad request when unformatted postcode is entered

### DIFF
--- a/app/uk/gov/hmrc/gform/controllers/helpers/FormDataHelpers.scala
+++ b/app/uk/gov/hmrc/gform/controllers/helpers/FormDataHelpers.scala
@@ -227,7 +227,7 @@ object FormDataHelpers {
             .addressLookup(formComponentId.baseComponentId) && formComponentId.modelComponentId.fold(_ => false)({
             case ModelComponentId.Atomic(_, Address.postcode) => true
             case _                                            => false
-          }) =>
+          }) || formModel.postcodeLookup(formComponentId.baseComponentId) =>
         PostcodeLookupValidation.normalisePostcode(value)
       case _ => value
     }


### PR DESCRIPTION
- Normalised the entered postcode in the postcode lookup component to fix the issue `Http status: 400, body: {"obj.postcode":[{"msg":["error.invalid"],"args":[]}]}`