### PR TITLE
GFORMS-2623 - If the first page of the form is hidden, `Enter the add…

### DIFF
--- a/app/uk/gov/hmrc/gform/addresslookup/AddressLookupController.scala
+++ b/app/uk/gov/hmrc/gform/addresslookup/AddressLookupController.scala
@@ -564,7 +564,7 @@ class AddressLookupController(
             formControllerRequestHandler
               .handleSuppressErrors(
                 formModelOptics,
-                List(cache.formTemplate.sectionNumberZero),
+                formModelOptics.formModelVisibilityOptics.formModel.availableSectionNumbers,
                 cacheData,
                 envelopeWithMapping,
                 validationService.validatePageModel,


### PR DESCRIPTION
…ress manually` raises an error when clicked