### PR TITLE
GFORMS-2623 - If the first page of the form is hidden, `Enter the add…

### DIFF
--- a/app/uk/gov/hmrc/gform/addresslookup/AddressLookupController.scala
+++ b/app/uk/gov/hmrc/gform/addresslookup/AddressLookupController.scala
@@ -658,7 +658,8 @@ class AddressLookupController(
                     formControllerRequestHandler
                       .handleFormValidation(
                         browserFormModelOptics,
-                        cache.formTemplate.sectionNumberZero,
+                        browserFormModelOptics.formModelVisibilityOptics.formModel.availableSectionNumbers.headOption
+                          .getOrElse(cache.formTemplate.sectionNumberZero),
                         cacheData,
                         envelopeWithMapping,
                         validationService.validatePageModel,


### PR DESCRIPTION
…ress manually` raises an error when clicked