### PR TITLE
Revert "GFORMS-2496: new form links goes to dashboardClean now (#2105)"

### DIFF
--- a/app/uk/gov/hmrc/gform/views/html/package.scala
+++ b/app/uk/gov/hmrc/gform/views/html/package.scala
@@ -77,7 +77,7 @@ package object html {
       attributes = Map.empty
     )
   private def startNewFormFooterItem(formTemplate: FormTemplate) = {
-    val newFormUrl = routes.NewFormController.dashboardClean(formTemplate._id).url
+    val newFormUrl = routes.NewFormController.dashboard(formTemplate._id).url
     new FooterItem(
       text = Some("New form"),
       href = Some(newFormUrl),


### PR DESCRIPTION
This reverts commit ec860c99393c8041457661be77dfaf9ecb0df335.