### PR TITLE
GFORMS-2773: When an expression is used in a page title it is missing…

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -617,9 +617,7 @@ class SectionRenderingService(
       maybeAccessCode,
       sectionNumber,
       page.sectionHeader(),
-      page.noPIITitle.fold(
-        page.title.valueWithoutInterpolations(formModelOptics.formModelVisibilityOptics.booleanExprResolver.resolve(_))
-      )(_.value()),
+      page.noPIITitle.fold(page.title.value())(_.value()),
       snippetsForFields,
       javascript,
       envelopeId,
@@ -1208,9 +1206,7 @@ class SectionRenderingService(
       maybeAccessCode,
       formTemplate.sectionNumberZero,
       page.sectionHeader(),
-      page.noPIITitle.fold(
-        page.title.valueWithoutInterpolations(formModelOptics.formModelVisibilityOptics.booleanExprResolver.resolve(_))
-      )(_.value()),
+      page.noPIITitle.fold(page.title.value())(_.value()),
       snippets,
       "",
       EnvelopeId(""),


### PR DESCRIPTION
… from the browser/tab title