### PR TITLE
GFORMS-2968 - Add the ability to define an instruction PDF without ha…

### DIFF
--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/Destination.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/Destination.scala
@@ -66,7 +66,7 @@ object Destination {
     dataOutputFormat: Option[DataOutputFormat],
     formdataXml: Boolean,
     backscan: Option[Boolean],
-    includeInstructionPdf: Boolean,
+    instructionPdfFields: Option[InstructionPdfFields],
     convertSingleQuotes: Option[Boolean],
     payload: Option[String],
     payloadType: TemplateType
@@ -180,7 +180,7 @@ case class UploadableHmrcDmsDestination(
   dataOutputFormat: Option[DataOutputFormat],
   formdataXml: Option[Boolean],
   closedStatus: Option[Boolean],
-  includeInstructionPdf: Option[Boolean] = None
+  instructionPdfFields: Option[InstructionPdfFields] = None
 ) {
 
   def toHmrcDmsDestination: Either[String, Destination.HmrcDms] =
@@ -197,7 +197,7 @@ case class UploadableHmrcDmsDestination(
       dataOutputFormat,
       formdataXml.getOrElse(false),
       closedStatus,
-      includeInstructionPdf.getOrElse(false),
+      instructionPdfFields,
       convertSingleQuotes,
       None,
       TemplateType.XML

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/InstructionPdfFields.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/InstructionPdfFields.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations
+
+import cats.Eq
+import play.api.libs.json.{ JsError, JsString, JsSuccess, Json, OFormat, Reads }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.OFormatWithTemplateReadFallback
+
+sealed trait InstructionPdfFields extends Product with Serializable
+
+object InstructionPdfFields {
+
+  case object All extends InstructionPdfFields
+  case object Ordered extends InstructionPdfFields
+
+  implicit val equal: Eq[InstructionPdfFields] = Eq.fromUniversalEquals
+
+  val reads: Reads[InstructionPdfFields] = Reads {
+    case JsString("all")     => JsSuccess(InstructionPdfFields.All)
+    case JsString("ordered") => JsSuccess(InstructionPdfFields.Ordered)
+    case otherwise =>
+      val got = otherwise match {
+        case JsString(str) => s"'$str'"
+        case _             => Json.prettyPrint(otherwise)
+      }
+      JsError("Invalid value for instructionPdfFields. Expected json String 'all' or 'ordered', but got: " + got)
+  }
+
+  implicit val format: OFormat[InstructionPdfFields] = OFormatWithTemplateReadFallback(reads)
+}

--- a/it/test/uk/gov/hmrc/gform/sample/FormTemplateSample.scala
+++ b/it/test/uk/gov/hmrc/gform/sample/FormTemplateSample.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.gform.Helpers.toSmartString
 import uk.gov.hmrc.gform.config.FileInfoConfig
 import uk.gov.hmrc.gform.models.Basic
 import uk.gov.hmrc.gform.sharedmodel.email.{ EmailTemplateId, LocalisedEmailTemplateId }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.InstructionPdfFields
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ AcknowledgementSection, Anonymous, AuthCtx, AuthInfo, ContinueOrDeletePage, DeclarationSection, EmailAuthConfig, FormComponent, FormComponentId, FormKind, FormTemplate, FormTemplateId, FormTemplateVersion, KeyDisplayWidth, LayoutDisplayWidth, OnePerUser, Page, SummarySection, TextConstraint, UserResearchUrl }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.Section.NonRepeatingPage
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.DestinationIncludeIf.HandlebarValue
@@ -118,7 +119,7 @@ trait FormTemplateSample {
           dataOutputFormat = Some(DataOutputFormat.XML),
           formdataXml = false,
           backscan = None,
-          includeInstructionPdf = true,
+          instructionPdfFields = Some(InstructionPdfFields.Ordered),
           convertSingleQuotes = None,
           payload = None,
           payloadType = TemplateType.XML

--- a/test/uk/gov/hmrc/gform/graph/DependencyGraphSpec.scala
+++ b/test/uk/gov/hmrc/gform/graph/DependencyGraphSpec.scala
@@ -717,7 +717,7 @@ class DependencyGraphSpec extends AnyFlatSpecLike with Matchers with FormModelSu
         Some(DataOutputFormat.XML),
         false,
         Some(false),
-        false,
+        None,
         None,
         None,
         TemplateType.XML

--- a/test/uk/gov/hmrc/gform/playcomponents/EmailAuthSessionPurgeFilterSpec.scala
+++ b/test/uk/gov/hmrc/gform/playcomponents/EmailAuthSessionPurgeFilterSpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate.Section.NonRepeatingPage
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.Destination.HmrcDms
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.DestinationIncludeIf.HandlebarValue
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.Destinations.DestinationList
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ DataOutputFormat, DestinationId, TemplateType }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ DataOutputFormat, DestinationId, InstructionPdfFields, TemplateType }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ AcknowledgementSection, AuthCtx, AuthInfo, ContinueOrDeletePage, DeclarationSection, EmailAuthConfig, FormComponent, FormComponentId, FormKind, FormTemplate, FormTemplateId, FormTemplateVersion, KeyDisplayWidth, LayoutDisplayWidth, OnePerUser, Page, SummarySection, TextConstraint, UserResearchUrl }
 import uk.gov.hmrc.gform.sharedmodel.{ AvailableLanguages, EmailVerifierService, LangADT, LocalisedString }
 import uk.gov.hmrc.gform.{ FormTemplateKey, Spec }
@@ -164,7 +164,7 @@ class EmailAuthSessionPurgeFilterSpec extends Spec {
           dataOutputFormat = Some(DataOutputFormat.XML),
           formdataXml = false,
           backscan = None,
-          includeInstructionPdf = true,
+          instructionPdfFields = Some(InstructionPdfFields.Ordered),
           convertSingleQuotes = None,
           payload = None,
           payloadType = TemplateType.XML

--- a/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
@@ -127,7 +127,7 @@ trait ExampleDestination { self: ExampleAuthConfig =>
     Some(DataOutputFormat.XML),
     true,
     Some(true),
-    false,
+    None,
     None,
     None,
     TemplateType.XML

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/UploadableDestinationSpec.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/destinations/UploadableDestinationSpec.scala
@@ -117,7 +117,7 @@ class UploadableDestinationSpec extends Spec {
       dataOutputFormat,
       Some(formdataXml),
       backscan,
-      Some(includeInstructionPdf)
+      instructionPdfFields
     )
   }
 

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/DestinationGen.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/DestinationGen.scala
@@ -38,16 +38,16 @@ trait DestinationGen {
 
   def hmrcDmsGen: Gen[Destination.HmrcDms] =
     for {
-      id                    <- destinationIdGen
-      dmsFormId             <- dmsFormIdGen
-      customerId            <- customerIdGen
-      classificationType    <- classificationTypeGen
-      businessArea          <- businessAreaGen
-      includeIf             <- includeIfGen()
-      failOnError           <- PrimitiveGen.booleanGen
-      formdataXml           <- PrimitiveGen.booleanGen
-      backscan              <- Gen.option(PrimitiveGen.booleanGen)
-      includeInstructionPdf <- PrimitiveGen.booleanGen
+      id                   <- destinationIdGen
+      dmsFormId            <- dmsFormIdGen
+      customerId           <- customerIdGen
+      classificationType   <- classificationTypeGen
+      businessArea         <- businessAreaGen
+      includeIf            <- includeIfGen()
+      failOnError          <- PrimitiveGen.booleanGen
+      formdataXml          <- PrimitiveGen.booleanGen
+      backscan             <- Gen.option(PrimitiveGen.booleanGen)
+      instructionPdfFields <- Gen.option(InstructionPdfFieldsGen.instructionPdfFieldsGen)
     } yield Destination
       .HmrcDms(
         id,
@@ -60,7 +60,7 @@ trait DestinationGen {
         Some(DataOutputFormat.XML),
         formdataXml,
         backscan,
-        includeInstructionPdf,
+        instructionPdfFields,
         None,
         None,
         TemplateType.XML

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/InstructionPdfFieldsGen.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/InstructionPdfFieldsGen.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.sharedmodel.formtemplate.generators
+
+import org.scalacheck.Gen
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.InstructionPdfFields
+
+trait InstructionPdfFieldsGen {
+  def instructionPdfFieldsGen: Gen[InstructionPdfFields] =
+    Gen.oneOf(InstructionPdfFields.All, InstructionPdfFields.Ordered)
+}
+
+object InstructionPdfFieldsGen extends InstructionPdfFieldsGen


### PR DESCRIPTION
…ving to specfiy order for all pages / fields

```
{
  "_id": "instruction-pdf",
  "formName": "Instruction pdf",
  "description": "",
  "version": 1,
  "acknowledgementSection": {
    "title": "Acknowledgement Page",
    "fields": []
  },
  "destinations": [
    {
      "id": "HMRCDMS",
      "type": "hmrcDms",
      "dmsFormId": "TST123",
      "customerId": "${choiceBasic}",
      "classificationType": "BT-NRU-Environmental",
      "businessArea": "FinanceOpsCorpT",
      "roboticsXml": true,
      "instructionPdfFields": "all"
    }
  ],
  "authConfig": {
    "authModule": "anonymous"
  },
  "sections": [
    {
      "title": "Instruction PDF - For operator eyes only!",
      "includeIf": "${form.phase.is.instructionPDF}",
      "fields": [
        {
          "id": "instructionAbc",
          "label": "Instruction Abc",
          "type": "text",
          "format": "text",
          "value": "${'instructionAbc'}",
          "submitMode": "readonly",
          "instruction": {
            "name": "Data for operator",
            "order": 1
          }
        }
      ]
    },
    {
      "title": "Page A",
      "fields": [
        {
          "id": "myCountry",
          "label": "Select country",
          "type": "text",
          "format": "lookup(country)",
          "instruction": {
            "name": "Data A",
            "order": 11
          }
        }
      ]
    },
    {
      "title": "Page A ${myCountry.column.CountryCode}",
      "fields": [
        {
          "id": "choiceBasic",
          "type": "choice",
          "label": "Basic choice",
          "notPII": true,
          "value": "1",
          "choices": [
            {
              "value": "bar",
              "en": "No",
              "cy": "Na"
            },
            {
              "value": "foo",
              "en": "Yes",
              "cy": "Iawn"
            }
          ],
          "instruction": {
            "name": "Data B",
            "order": 2
          }
        }
      ]
    },
    {
      "title": "Page B '${choiceBasic}'",
      "includeIf": "${choiceBasic contains 'foo'}",
      "fields": [
        {
          "id": "dummy",
          "type": "text",
          "label": "Dummy B",
          "format": "shortText",
          "instruction": {
            "name": "Data C",
            "order": 3
          }
        }
      ]
    },
    {
      "title": "Page C '${choiceBasic}'",
      "includeIf": "${choiceBasic contains 'bar'}",
      "fields": [
        {
          "id": "dummyC",
          "type": "text",
          "label": "Dummy C",
          "format": "shortText",
          "instruction": {
            "name": "Data D",
            "order": 4
          }
        }
      ]
    }
  ]
}
```