### PR TITLE
GFORMS-3073 - Smart strings are not playing back correctly in tables …

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/gform/SectionRenderingService.scala
@@ -1908,23 +1908,27 @@ class SectionRenderingService(
   )(implicit
     sse: SmartStringEvaluator
   ): SmartString = {
+    val resolver = formModelOptics.formModelVisibilityOptics.booleanExprResolver.resolve(_)
     val lString: LocalisedString =
       sString.localised(formModelOptics.formModelVisibilityOptics.booleanExprResolver.resolve(_))
     SmartString(
-      sString.allInterpolations.zipWithIndex.foldLeft(
-        lString
-      ) {
-        case (accumulatedString, (formCtx: FormCtx, index)) =>
-          formModelOptics.formModelRenderPageOptics.formModel.fcLookup(formCtx.formComponentId) match {
-            case IsText(text) =>
-              text.suffix.fold(accumulatedString)(ss =>
-                accumulatedString.replace(s"{$index}", s"{$index} ${ss.value()}")
-              )
-            case _ => accumulatedString
-          }
-        case _ => lString
-      },
-      sString.allInterpolations
+      sString
+        .interpolations(resolver)
+        .zipWithIndex
+        .foldLeft(
+          lString
+        ) {
+          case (accumulatedString, (formCtx: FormCtx, index)) =>
+            formModelOptics.formModelRenderPageOptics.formModel.fcLookup(formCtx.formComponentId) match {
+              case IsText(text) =>
+                text.suffix.fold(accumulatedString)(ss =>
+                  accumulatedString.replace(s"{$index}", s"{$index} ${ss.value()}")
+                )
+              case _ => accumulatedString
+            }
+          case _ => lString
+        },
+      sString.interpolations(resolver)
     )
   }
 


### PR DESCRIPTION
…with alternate values based on includeIf expression

```
{
  "_id": "multi-value-string-issue",
  "formName": "Multi value string issue",
  "description": "Multi value string issue",
  "version": 1,
  "emailTemplateId": "dynamicEmail_confirmation",
  "authConfig": {
    "authModule": "anonymous"
  },
  "sections": [
    {
      "title": "Enter amount",
      "fields": [
        {
          "id": "amount",
          "type": "text",
          "format": "number",
          "value": "${'123'}"
        }
      ]
    },
    {
      "title": [
        {
          "en": "Table"
        }
      ],
      "fields": [
        {
          "id": "gformTable",
          "summaryValue": [
            {
              "en": "X"
            }
          ],
          "type": "table",
          "label": [
            {
              "en": "Header row and Value row must be equal"
            }
          ],
          "header": [
            {
              "en": "${amount}, ${amount}, ${amount}, ${amount}"
            }
          ],
          "rows": [
            {
              "values": [
                {
                  "value": [
                    {
                      "en": "${'Foo'} ${'Bar'} ${'Baz'}",
                      "includeIf": "${1 = 2}"
                    },
                    {
                      "en": "${amount}, ${amount}, ${amount}, ${amount}"
                    }
                  ]
                }
              ]
            }
          ]
        }
      ]
    }
  ],
  "acknowledgementSection": {
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}
```