### PR TITLE
GFORMS-3161 - Deleting last ATL iteration from summary page crashes w…

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/processor/FormProcessor.scala
+++ b/app/uk/gov/hmrc/gform/gform/processor/FormProcessor.scala
@@ -148,20 +148,16 @@ class FormProcessor(
         formModelOptics,
         EnteredVariadicFormData.empty,
         true
-      ) { _ => _ => maybeSectionNumber =>
+      ) { _ => _ => _ =>
         val pageIdToRemove = updFormModel.brackets.addToListBracket(addToListId).source.pageIdToDisplayAfterRemove
         val pageIdSectionNumberMap = updFormModel.pageIdSectionNumberMap
         val sectionNumber =
           if (isLastIteration) {
             pageIdToRemove.fold(
-              maybeSectionNumber match {
-                case SectionOrSummary.Section(s) =>
-                  addToListBracket.iterationForSectionNumber(s).defaultPageOrFirstSectionNumber
-                case _ => sn
-              }
+              addToListBracket.iterationForSectionNumber(sn).defaultPageOrFirstSectionNumber
             )(pageId =>
               computePageLink(pageId, pageIdSectionNumberMap).getOrElse(
-                throw new Exception(s"Unable to find section number for pageId: ${pageIdToRemove.get}")
+                throw new Exception(s"Unable to find section number for pageId: $pageId")
               )
             )
           } else


### PR DESCRIPTION
…ith Invalid sectionNumber

```
{
  "_id": "last-iteration-delete",
  "formName": "Add to list",
  "version": 1,
  "description": "Add to list",
  "authConfig": {
    "authModule": "anonymous"
  },
  "sections": [
    {
      "type": "addToList",
      "summaryName": "Directors",
      "title": "This is for AddToList",
      "shortName": "Director $n of ${directors.count}",
      "description": "${name}",
      "summaryDescription": "${name}",
      "addAnotherQuestion": {
        "id": "directors",
        "type": "choice",
        "label": "So you want to add another director?",
        "format": "yesno"
      },
      "pages": [
        {
          "title": "Name",
          "fields": [
            {
              "id": "name",
              "type": "text",
              "format": "text"
            }
          ]
        }
      ]
    },
    {
      "title": "Last page",
      "fields": [
        {
          "id": "lastPage",
          "type": "text",
          "format": "text"
        }
      ]
    }
  ],
  "declarationSection": {
    "shortName": "Declaration",
    "title": "Declaration",
    "fields": []
  },
  "acknowledgementSection": {
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}
```