### PR TITLE
Fixing Bobby warnings

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@ $hmrc-assets-path: "/submissions/assets/lib/hmrc-frontend/hmrc/";
 $govuk-new-link-styles: true;
 $govuk-new-typography-scale: true;
 
-@import "lib/govuk-frontend/dist/govuk/all";
+@import "lib/govuk-frontend/dist/govuk/index";
 @import "lib/hmrc-frontend/hmrc/all";
 
 .app-reference-number {

--- a/build.sbt
+++ b/build.sbt
@@ -86,8 +86,7 @@ lazy val microservice = (project in file("."))
     uglify / excludeFilter ~= { _ || "builder.js" },
     pipelineStages := Seq(digest),
     Assets / pipelineStages := Seq(concat, uglify),
-    Assets / unmanagedResourceDirectories += baseDirectory.value / "builder" / "dist",
-    uglifyCompressOptions := Seq("warnings=false")
+    Assets / unmanagedResourceDirectories += baseDirectory.value / "builder" / "dist"
   )
   .settings(
     resolvers ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,10 +24,10 @@ addDependencyTreePlugin
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 
-addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
+addSbtPlugin("com.github.sbt" % "sbt-concat" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-uglify" % "3.0.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+addSbtPlugin("com.github.sbt" % "sbt-digest" % "2.0.0")
 
 addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.0.1")


### PR DESCRIPTION
[warn] WARNING: Your build has 3 bobby warning(s). Please take action to fix these before the listed date, or they will become violations that fail your build [warn]  (1) com.typesafe.sbt:sbt-digest (1.1.4)
[warn]      Reason: Use com.github.sbt:sbt-digest instead
[warn]  (2) com.typesafe.sbt:sbt-uglify (2.0.0)
[warn]      Reason: Use com.github.sbt:sbt-uglify instead
[warn]  (3) net.ground5hark.sbt:sbt-concat (0.2.0)
[warn]      Reason: Use com.github.sbt:sbt-concat instead