### PR TITLE
GFORMS-3178 - count from a field in ATL is not working in a section i…

### DIFF
--- a/app/uk/gov/hmrc/gform/models/FormModel.scala
+++ b/app/uk/gov/hmrc/gform/models/FormModel.scala
@@ -288,7 +288,7 @@ case class FormModel[A <: PageMode](
       case FormCtx(formComponentId) => explicitTypedExpr(expr, formComponentId)
       case DateCtx(_)               => TypeInfo(expr, StaticTypeData(ExprType.dateString, None))
       case IsNumberConstant(_) | PeriodExt(_, _) | UserCtx(UserField.Enrolment(_, _, Some(UserFieldFunc.Count))) |
-          Size(_, _) | CsvCountryCountCheck(_, _, _) =>
+          Size(_, _) | CsvCountryCountCheck(_, _, _) | Count(_) =>
         TypeInfo(expr, StaticTypeData(ExprType.number, Some(Number())))
       case DataRetrieveCtx(_, DataRetrieve.Attribute("registeredOfficeAddress")) |
           DataRetrieveCtx(_, DataRetrieve.Attribute("agencyAddress")) =>

--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/Expr.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/Expr.scala
@@ -52,7 +52,7 @@ sealed trait Expr extends Product with Serializable {
             }
           case _ => loop(field1)
         }
-      case Count(formComponentId: FormComponentId) => FormCtx(formComponentId.withFirstIndex) :: Nil
+      case Count(formComponentId: FormComponentId) => expr :: Nil
       case Index(formComponentId: FormComponentId) => FormCtx(formComponentId.withFirstIndex) :: Nil
       case AuthCtx(_)                              => expr :: Nil
       case UserCtx(_)                              => expr :: Nil


### PR DESCRIPTION
…ncludeIf expression

```
{
  "_id": "bug-add-to-list-dynamic",
  "formName": "Task list",
  "description": "",
  "version": 1,
  "emailTemplateId": "eeitt_submission_confirmation",
  "authConfig": {
    "authModule": "anonymous"
  },
  "expressions": {
    "nameCount": "name.count"
  },
  "booleanExpressions": {
    "atlCount": "nameCount > 2"
  },
  "sections": [
    {
      "type": "addToList",
      "title": "People",
      "shortName": "Person $n",
      "summaryDescription": "Person $n",
      "summaryName": "Person $n",
      "description": "Person $n ${nameCount}",
      "addAnotherQuestion": {
        "id": "addAnotherPerson",
        "type": "choice",
        "label": "Do you want to add another person?",
        "format": "yesno"
      },
      "pages": [
        {
          "title": "Enter name",
          "fields": [
            {
              "id": "name",
              "type": "text",
              "format": "text"
            }
          ]
        }
      ]
    },
    {
      "title": "Which person? ${nameCount}",
      "includeIf": "${atlCount}",
      "fields": [
        {
          "id": "personDesc",
          "type": "text",
          "format": "text"
        }
      ]
    }
  ],
  "acknowledgementSection": {
    "title": "Confirmation page ",
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}
```