### PR TITLE
GFORMS-3215 - Handle evaluation correctly when concat expression is applied to a...

### DIFF
--- a/app/uk/gov/hmrc/gform/eval/smartstring/SmartStringEvaluatorFactory.scala
+++ b/app/uk/gov/hmrc/gform/eval/smartstring/SmartStringEvaluatorFactory.scala
@@ -102,6 +102,8 @@ private class Executor(
         typeInfo.expr match {
           case FormCtx(formComponentId) if typeInfo.staticTypeData.exprType == ExprType.ChoiceSelection =>
             evalChoiceAsString(formComponentId, typeInfo, markDown)
+          case IndexOf(formComponentId, index) if typeInfo.staticTypeData.exprType == ExprType.ChoiceSelection =>
+            evalChoiceAsString(formComponentId.withIndex(index.+(1)), typeInfo, false)
           case _ => stringRepresentation(typeInfo)
         }
       case _ =>

--- a/app/uk/gov/hmrc/gform/eval/smartstring/SmartStringEvaluatorFactory.scala
+++ b/app/uk/gov/hmrc/gform/eval/smartstring/SmartStringEvaluatorFactory.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SmartString }
 import uk.gov.hmrc.gform.views.summary.TextFormatter
 import uk.gov.hmrc.gform.gform.{ ConcatFormatSubstituter, ConcatFormatSubstitutions, Substituter }
 import ConcatFormatSubstituter._
+import cats.implicits.catsSyntaxEq
 import uk.gov.hmrc.gform.eval.ExprType.ChoiceSelection
 
 import scala.jdk.CollectionConverters._
@@ -93,9 +94,11 @@ private class Executor(
       )
   }
 
+  private def getTypeInfo(expr: Expr): TypeInfo = formModelVisibilityOptics.formModel.toFirstOperandTypeInfo(expr)
+
   private def formatExpr(expr: Expr, markDown: Boolean): String = {
 
-    val typeInfo: TypeInfo = formModelVisibilityOptics.formModel.toFirstOperandTypeInfo(expr)
+    val typeInfo: TypeInfo = getTypeInfo(expr)
 
     val interpolated = typeInfo.staticTypeData.exprType match {
       case ExprType.ChoiceSelection =>
@@ -109,11 +112,9 @@ private class Executor(
       case _ =>
         expr match {
           case NumberedList(fcId) =>
-            val fcIdTypeInfo = formModelVisibilityOptics.formModel.toFirstOperandTypeInfo(FormCtx(fcId))
-            govukListRepresentation(fcIdTypeInfo, markDown = markDown, isBulleted = false, fcId = fcId)
+            govukListRepresentation(getTypeInfo(FormCtx(fcId)), markDown = markDown, isBulleted = false, fcId = fcId)
           case BulletedList(fcId) =>
-            val fcIdTypeInfo = formModelVisibilityOptics.formModel.toFirstOperandTypeInfo(FormCtx(fcId))
-            govukListRepresentation(fcIdTypeInfo, markDown = markDown, isBulleted = true, fcId = fcId)
+            govukListRepresentation(getTypeInfo(FormCtx(fcId)), markDown = markDown, isBulleted = true, fcId = fcId)
           case ChoicesRevealedField(fcId) =>
             formModelVisibilityOptics.formModel.fcLookup
               .get(fcId)
@@ -170,26 +171,26 @@ private class Executor(
   }
 
   private def evalChoice(fcId: FormComponentId, typeInfo: TypeInfo, markDown: Boolean): List[String] =
-    formModelVisibilityOptics.formModel.fcLookup
-      .get(fcId)
-      .collect {
-        case IsChoice(choice) =>
-          val optionsList = getChoiceOptions(choice)
-          val orderedKeys = optionsList.keys.toSet
-          formModelVisibilityOptics
-            .evalAndApplyTypeInfo(typeInfo)
-            .optionRepresentation
-            .map { repr =>
-              repr.collect { case key if orderedKeys.contains(key) => apply(optionsList(key), markDown) }
-            }
-            .getOrElse(Nil)
-        case IsRevealingChoice(revealingChoice) =>
-          revealingChoice.options.map(c => apply(summaryValueOrLabel(c.choice.label, c.choice.summaryValue), markDown))
-        case _ =>
-          List(stringRepresentation(typeInfo))
-      }
-      .getOrElse(Seq.empty)
-      .toList
+    formModelVisibilityOptics.formModel.fcLookup.get(fcId) match {
+      case Some(IsChoice(choice)) =>
+        val optionsList = getChoiceOptions(choice)
+        val orderedKeys = optionsList.keys.toSet
+        formModelVisibilityOptics
+          .evalAndApplyTypeInfo(typeInfo)
+          .optionRepresentation
+          .map(_.collect { case key if orderedKeys.contains(key) => apply(optionsList(key), markDown) })
+          .getOrElse(Nil)
+          .toList
+      case Some(IsRevealingChoice(revealingChoice)) =>
+        revealingChoice.options.map(c => apply(summaryValueOrLabel(c.choice.label, c.choice.summaryValue), markDown))
+      case Some(_) =>
+        List(stringRepresentation(typeInfo))
+      case None =>
+        formModelVisibilityOptics.formModel.fcLookup.collect {
+          case (formCompId, _) if formCompId.baseComponentId === fcId.baseComponentId =>
+            evalChoiceAsString(formCompId, getTypeInfo(FormCtx(formCompId)), markDown)
+        }.toList
+    }
 
   private def evalChoiceAsString(fcId: FormComponentId, typeInfo: TypeInfo, markDown: Boolean): String =
     evalChoice(fcId, typeInfo, markDown).mkString(", ")

--- a/test/uk/gov/hmrc/gform/eval/smartstring/RealSmartStringEvaluatorFactorySpec.scala
+++ b/test/uk/gov/hmrc/gform/eval/smartstring/RealSmartStringEvaluatorFactorySpec.scala
@@ -37,7 +37,7 @@ import uk.gov.hmrc.gform.models.ids.ModelComponentId
 import uk.gov.hmrc.gform.models.optics.DataOrigin
 import uk.gov.hmrc.gform.models.{ FormModel, Interim, SectionSelector, SectionSelectorType }
 import uk.gov.hmrc.gform.sharedmodel.form.{ Form, FormData, FormField, FormModelOptics, TaskIdTaskStatusMapping, ThirdPartyData }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ BulletedList, Checkbox, Choice, Concat, Constant, Expr, FileSizeLimit, FormComponent, FormComponentId, FormCtx, FormPhase, FormTemplate, FormTemplateContext, HideZeroDecimals, Horizontal, IfElse, IsFalse, Number, NumberedList, OptionData, PositiveNumber, Radio, RepeatedComponentsDetails, RevealingChoice, RevealingChoiceElement, RoundingMode, Sterling, Value, Vertical }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ BulletedList, Checkbox, Choice, Concat, Constant, Expr, FileSizeLimit, FormComponent, FormComponentId, FormCtx, FormPhase, FormTemplate, FormTemplateContext, HideZeroDecimals, Horizontal, IfElse, IndexOf, IsFalse, Number, NumberedList, OptionData, PositiveNumber, Radio, RepeatedComponentsDetails, RevealingChoice, RevealingChoiceElement, RoundingMode, Sterling, Value, Vertical }
 import uk.gov.hmrc.gform.sharedmodel._
 import uk.gov.hmrc.http.{ HeaderCarrier, SessionId }
 
@@ -803,5 +803,109 @@ class RealSmartStringEvaluatorFactorySpec
       )
 
     result shouldBe """<ul class="govuk-list govuk-list--bullet"><li>Option 2</li></ul>"""
+  }
+
+  "evaluate SmartString using concat with reference to a choice component at ATL index" in new TestFixture {
+    lazy val choiceField: FormComponent = buildFormComponent(
+      "choiceField",
+      Choice(
+        Radio,
+        toOptionData(NonEmptyList.of("Choice 1", "Choice 2", "Choice 3")),
+        Vertical,
+        List.empty,
+        None,
+        None,
+        None,
+        LocalisedString(Map(LangADT.En -> "or", LangADT.Cy -> "neu")),
+        None,
+        None,
+        false
+      ),
+      None
+    )
+    lazy val (modelCompId1, modelCompId2) =
+      (choiceField.modelComponentId.expandWithPrefix(1), choiceField.modelComponentId.expandWithPrefix(2))
+    override lazy val indexedComponentIds: List[ModelComponentId] =
+      List(modelCompId1, modelCompId2)
+    override lazy val form: Form =
+      buildForm(
+        FormData(
+          List(
+            FormField(modelCompId1, "1"),
+            FormField(modelCompId2, "2")
+          )
+        )
+      )
+    override lazy val formTemplate: FormTemplate = buildFormTemplate(
+      destinationList,
+      sections = List(repeatingSection(title = "page1", fields = List(choiceField), None, Constant("2")))
+    )
+    override lazy val exprMap: Map[Expr, ExpressionResult] = Map(
+      FormCtx(modelCompId1.toFormComponentId) -> OptionResult(List("1")),
+      FormCtx(modelCompId2.toFormComponentId) -> OptionResult(List("2"))
+    )
+
+    val result: String = smartStringEvaluator
+      .apply(
+        toSmartStringExpression(
+          "{0}",
+          Concat(List(IndexOf(FormComponentId("choiceField"), 1)))
+        ),
+        false
+      )
+
+    result shouldBe "Choice 3"
+  }
+
+  "evaluate SmartString using concat with reference to a checkbox choice component at ATL index" in new TestFixture {
+    lazy val choiceField: FormComponent = buildFormComponent(
+      "choiceField",
+      Choice(
+        Checkbox,
+        toValueBasedOptionData(NonEmptyList.of("Choice 1", "Choice 2", "Choice 3")),
+        Vertical,
+        List.empty,
+        None,
+        None,
+        None,
+        LocalisedString(Map(LangADT.En -> "or", LangADT.Cy -> "neu")),
+        None,
+        None,
+        false
+      ),
+      None
+    )
+    lazy val (modelCompId1, modelCompId2) =
+      (choiceField.modelComponentId.expandWithPrefix(1), choiceField.modelComponentId.expandWithPrefix(2))
+    override lazy val indexedComponentIds: List[ModelComponentId] =
+      List(modelCompId1, modelCompId2)
+    override lazy val form: Form =
+      buildForm(
+        FormData(
+          List(
+            FormField(modelCompId1, "Choice 2,Choice 3"),
+            FormField(modelCompId2, "Choice 1")
+          )
+        )
+      )
+    override lazy val formTemplate: FormTemplate = buildFormTemplate(
+      destinationList,
+      sections = List(repeatingSection(title = "page1", fields = List(choiceField), None, Constant("2")))
+    )
+    override lazy val exprMap: Map[Expr, ExpressionResult] = Map(
+      FormCtx(modelCompId1.toFormComponentId) -> OptionResult(List("Choice 2", "Choice 3")),
+      FormCtx(modelCompId2.toFormComponentId) -> OptionResult(List("Choice 1"))
+    )
+
+    val result: String = smartStringEvaluator
+      .apply(
+        toSmartStringExpression(
+          "{0}",
+          Concat(List(IndexOf(FormComponentId("choiceField"), 0)))
+        ),
+        false
+      )
+
+    result shouldBe "Choice 2, Choice 3"
   }
 }

--- a/test/uk/gov/hmrc/gform/eval/smartstring/RealSmartStringEvaluatorFactorySpec.scala
+++ b/test/uk/gov/hmrc/gform/eval/smartstring/RealSmartStringEvaluatorFactorySpec.scala
@@ -908,4 +908,56 @@ class RealSmartStringEvaluatorFactorySpec
 
     result shouldBe "Choice 2, Choice 3"
   }
+
+  "evaluate SmartString using a non-indexed reference to a checkbox choice component in ATL" in new TestFixture {
+    lazy val choiceField: FormComponent = buildFormComponent(
+      "choiceField",
+      Choice(
+        Checkbox,
+        toValueBasedOptionData(NonEmptyList.of("Choice 1", "Choice 2", "Choice 3")),
+        Vertical,
+        List.empty,
+        None,
+        None,
+        None,
+        LocalisedString(Map(LangADT.En -> "or", LangADT.Cy -> "neu")),
+        None,
+        None,
+        false
+      ),
+      None
+    )
+    lazy val (modelCompId1, modelCompId2) =
+      (choiceField.modelComponentId.expandWithPrefix(1), choiceField.modelComponentId.expandWithPrefix(2))
+    override lazy val indexedComponentIds: List[ModelComponentId] =
+      List(modelCompId1, modelCompId2)
+    override lazy val form: Form =
+      buildForm(
+        FormData(
+          List(
+            FormField(modelCompId1, "Choice 2,Choice 3"),
+            FormField(modelCompId2, "Choice 1")
+          )
+        )
+      )
+    override lazy val formTemplate: FormTemplate = buildFormTemplate(
+      destinationList,
+      sections = List(repeatingSection(title = "page1", fields = List(choiceField), None, Constant("2")))
+    )
+    override lazy val exprMap: Map[Expr, ExpressionResult] = Map(
+      FormCtx(modelCompId1.toFormComponentId) -> OptionResult(List("Choice 2", "Choice 3")),
+      FormCtx(modelCompId2.toFormComponentId) -> OptionResult(List("Choice 1"))
+    )
+
+    val result: String = smartStringEvaluator
+      .apply(
+        toSmartStringExpression(
+          "{0}",
+          FormCtx(FormComponentId("choiceField"))
+        ),
+        false
+      )
+
+    result shouldBe "Choice 2, Choice 3, Choice 1"
+  }
 }


### PR DESCRIPTION
...choice with index like in concat(atlChoice[1])

Also allows direct evaluation of a choice within ATL without an index e.g. ${atlChoice}. This returns all choice options selected across the component instances in ATL. 