### PR TITLE
GFORMS-3262 - Allow includeIf on String or en/cy object to evaluate form phase

### DIFF
--- a/app/uk/gov/hmrc/gform/models/optics/FormModelVisibilityOptics.scala
+++ b/app/uk/gov/hmrc/gform/models/optics/FormModelVisibilityOptics.scala
@@ -61,7 +61,9 @@ case class FormModelVisibilityOptics[D <: DataOrigin](
     evalAndApplyTypeInfo(typeInfo)
   }
 
-  val booleanExprResolver = BooleanExprResolver(booleanExpr => evalIncludeIfExpr(IncludeIf(booleanExpr), None))
+  val booleanExprResolver: BooleanExprResolver = BooleanExprResolver(booleanExpr =>
+    evalIncludeIfExpr(IncludeIf(booleanExpr), recalculationResult.evaluationContext.formPhase)
+  )
 
   def evalAndApplyTypeInfo(typeInfo: TypeInfo): ExpressionResultWithTypeInfo =
     ExpressionResultWithTypeInfo(


### PR DESCRIPTION
BooleanExprResolver should use form phase from evaluation context when evaluating IncludeIf expression