### PR TITLE
GFORMS-3315 - Production Issue - Index 0 out of bounds for length 0 (…

### DIFF
--- a/app/uk/gov/hmrc/gform/controllers/helpers/FormDataHelpers.scala
+++ b/app/uk/gov/hmrc/gform/controllers/helpers/FormDataHelpers.scala
@@ -234,6 +234,8 @@ object FormDataHelpers {
       case Some(formComponent) if formComponent.isNino   => value.toUpperCase.trim
       case Some(formComponent) if formComponent.isEORI   => value.toUpperCase.trim
       case Some(formComponent) if formComponent.isUkEORI => value.toUpperCase.trim
+      case Some(formComponent) if formComponent.isText =>
+        value.replaceAll("`", "") //remove backticks to prevent unintended Markdown formatting in generated PDFs
       case None if formComponentId.modelComponentId.fold(_ => false)({
             case ModelComponentId.Atomic(_, Date.day)   => true
             case ModelComponentId.Atomic(_, Date.month) => true

--- a/app/uk/gov/hmrc/gform/ops/package.scala
+++ b/app/uk/gov/hmrc/gform/ops/package.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.gform
 
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ ChildBenefitNumber, CompanyRegistrationNumber, CtUTR, EORI, FormComponent, NINO, Number, PayeReference, PositiveNumber, ReferenceNumber, SaUTR, Sterling, Text, TextArea, UkBankAccountNumber, UkEORI, UkSortCodeFormat, UkVrn, WholeSterling }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ ChildBenefitNumber, CompanyRegistrationNumber, CtUTR, EORI, FormComponent, NINO, Number, PayeReference, PositiveNumber, ReferenceNumber, SaUTR, ShortText, Sterling, Text, TextArea, TextWithRestrictions, UkBankAccountNumber, UkEORI, UkSortCodeFormat, UkVrn, WholeSterling }
 
 package object ops {
 
@@ -107,6 +107,12 @@ package object ops {
       case Text(SaUTR, _, _, _, _, _, _) => true
       case Text(CtUTR, _, _, _, _, _, _) => true
       case _                             => false
+    }
+
+    def isText = formComponent.`type` match {
+      case Text(TextWithRestrictions(_, _), _, _, _, _, _, _) => true
+      case Text(ShortText(_, _), _, _, _, _, _, _)            => true
+      case _                                                  => false
     }
   }
 }


### PR DESCRIPTION
…Fix issue where double apostrophe causing the text to mono space)

{
  "_id": "mono-space-issue",
  "formName": "PDF generation issue with double backticks",
  "description": "",
  "version": 1,
  "languages": ["en", "cy"],
  "emailTemplateId": "eeitt_submission_confirmation",
  "authConfig": {
    "authModule": "anonymous"
  },
  "sections": [
    {
      "type": "addToList",
      "title": "Tax owed",
      "summaryName": {
        "en": "Employers added",
        "cy": "Cyflogwyr sydd wedi’u hychwanegu"
      },
      "shortName": {
        "en": "Employer $n",
        "cy": "Cyflogwr $n"
      },
      "description": {
        "en": "**$n .** ${employerName}",
        "cy": "**$n .** ${employerName}"
      },
      "summaryDescription": {
        "en": "${employerName}",
        "cy": "${employerName}"
      },
      "addAnotherQuestion": {
        "id": "addAnotherTax",
        "type": "choice",
        "label": "Do you want to add another tax?",
        "labelSize": "s",
        "format": "yesno",
        "errorMessage": "Select yes if you want to add another tax "
      },
      "pages": [
        {
          "title": "What tax?",
          "fields": [
            {
              "id": "employerName",
              "type": "text",
              "format": "text"
            }
          ]
        }
      ]
    }
  ],
  "acknowledgementSection": {
    "title": "Confirmation page ",
    "fields": []
  },
  "destinations": [
    {
      "id": "transitionToSubmitted",
      "type": "stateTransition",
      "requiredState": "Submitted"
    }
  ]
}