### PR TITLE
Gforms-3306 - Performance improvements to gForms frontend for Add to List

### DIFF
--- a/app/uk/gov/hmrc/gform/eval/EvaluationContext.scala
+++ b/app/uk/gov/hmrc/gform/eval/EvaluationContext.scala
@@ -47,7 +47,7 @@ final case class EvaluationContext(
   pageIdSectionNumberMap: Map[ModelPageId, SectionNumber],
   lang: LangADT,
   messages: Messages,
-  indexedComponentIds: List[ModelComponentId],
+  indexedComponentIds: Map[BaseComponentId, List[ModelComponentId]],
   taxPeriodYear: Set[BaseComponentId],
   fileSizeLimit: FileSizeLimit,
   dataRetrieveAll: DataRetrieveAll,

--- a/app/uk/gov/hmrc/gform/eval/EvaluationResults.scala
+++ b/app/uk/gov/hmrc/gform/eval/EvaluationResults.scala
@@ -61,9 +61,7 @@ case class EvaluationResults(
     evaluationContext: EvaluationContext
   ): Boolean = {
     val isModelFormComponentIdPure = modelComponentId.indexedComponentId.isPure
-    val isReferenceIndexed = evaluationContext.indexedComponentIds.exists(
-      _.baseComponentId === modelComponentId.baseComponentId
-    )
+    val isReferenceIndexed = evaluationContext.indexedComponentIds.contains(modelComponentId.baseComponentId)
     isModelFormComponentIdPure && isReferenceIndexed
   }
 

--- a/app/uk/gov/hmrc/gform/eval/EvaluationResults.scala
+++ b/app/uk/gov/hmrc/gform/eval/EvaluationResults.scala
@@ -73,7 +73,7 @@ case class EvaluationResults(
     evaluationContext: EvaluationContext
   ): ExpressionResult = {
     val modelComponentId = expr.formComponentId.modelComponentId
-    if (false) { //if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
+    if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
       ListResult(
         exprMap
           .collect {
@@ -511,7 +511,7 @@ case class EvaluationResults(
             .addressLookup(formComponentId.baseComponentId) =>
         whenVisible(formComponentId) {
           val modelComponentId = formComponentId.modelComponentId
-          if (false) { //if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
+          if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
             val addresses = recData.variadicFormData.distinctIndexedComponentIds(formComponentId.modelComponentId).map {
               indexedComponentId =>
                 getAddressResult(indexedComponentId)

--- a/app/uk/gov/hmrc/gform/eval/EvaluationResults.scala
+++ b/app/uk/gov/hmrc/gform/eval/EvaluationResults.scala
@@ -73,7 +73,7 @@ case class EvaluationResults(
     evaluationContext: EvaluationContext
   ): ExpressionResult = {
     val modelComponentId = expr.formComponentId.modelComponentId
-    if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
+    if (false) { //if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
       ListResult(
         exprMap
           .collect {
@@ -511,7 +511,7 @@ case class EvaluationResults(
             .addressLookup(formComponentId.baseComponentId) =>
         whenVisible(formComponentId) {
           val modelComponentId = formComponentId.modelComponentId
-          if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
+          if (false) { //if (isPureAndRefereceIndexed(modelComponentId, evaluationContext)) {
             val addresses = recData.variadicFormData.distinctIndexedComponentIds(formComponentId.modelComponentId).map {
               indexedComponentId =>
                 getAddressResult(indexedComponentId)
@@ -1116,22 +1116,15 @@ case class EvaluationResults(
     booleanExprResolver: BooleanExprResolver,
     evaluationContext: EvaluationContext
   ): ExpressionResult =
-    typeInfo.staticTypeData.exprType.fold { number =>
-      evalNumber(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { string =>
-      evalString(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { choiceSelection =>
-      evalString(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { dateString =>
-      evalDateString(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { addressString =>
-      evalString(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { period =>
-      evalPeriod(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { taxPeriod =>
-      evalTaxPeriod(typeInfo, recData, booleanExprResolver, evaluationContext)
-    } { illegal =>
-      ExpressionResult.invalid("[evalTyped] Illegal expression " + typeInfo.expr)
+    typeInfo.staticTypeData.exprType match {
+      case _: ExprType.Number.type          => evalNumber(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.String.type          => evalString(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.ChoiceSelection.type => evalString(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.DateString.type      => evalDateString(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.AddressString.type   => evalString(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.Period.type          => evalPeriod(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.TaxPeriod.type       => evalTaxPeriod(typeInfo, recData, booleanExprResolver, evaluationContext)
+      case _: ExprType.Illegal.type         => ExpressionResult.invalid("[evalTyped] Illegal expression " + typeInfo.expr)
     }
 }
 

--- a/app/uk/gov/hmrc/gform/eval/ExprType.scala
+++ b/app/uk/gov/hmrc/gform/eval/ExprType.scala
@@ -18,35 +18,7 @@ package uk.gov.hmrc.gform.eval
 
 import cats.Eq
 
-sealed trait ExprType extends Product with Serializable {
-  def fold[B](
-    a: ExprType.Number.type => B
-  )(
-    b: ExprType.String.type => B
-  )(
-    c: ExprType.ChoiceSelection.type => B
-  )(
-    d: ExprType.DateString.type => B
-  )(
-    e: ExprType.AddressString.type => B
-  )(
-    f: ExprType.Period.type => B
-  )(
-    g: ExprType.TaxPeriod.type => B
-  )(
-    h: ExprType.Illegal.type => B
-  ): B =
-    this match {
-      case t: ExprType.Number.type          => a(t)
-      case t: ExprType.String.type          => b(t)
-      case t: ExprType.ChoiceSelection.type => c(t)
-      case t: ExprType.DateString.type      => d(t)
-      case t: ExprType.AddressString.type   => e(t)
-      case t: ExprType.Period.type          => f(t)
-      case t: ExprType.TaxPeriod.type       => g(t)
-      case t: ExprType.Illegal.type         => h(t)
-    }
-}
+sealed trait ExprType extends Product with Serializable
 
 object ExprType {
 

--- a/app/uk/gov/hmrc/gform/models/FormModel.scala
+++ b/app/uk/gov/hmrc/gform/models/FormModel.scala
@@ -380,8 +380,7 @@ object FormModel {
     modelComponentList.foreach {
       case mcId if mcId.indexedComponentId.isIndexed =>
         val bcId = mcId.baseComponentId
-        val l = map.getOrElse(bcId, mutable.ListBuffer.empty).addOne(mcId)
-        map.addOne((bcId, l))
+        map.getOrElseUpdate(bcId, mutable.ListBuffer.empty) += mcId
       case _ => ()
     }
     map

--- a/app/uk/gov/hmrc/gform/models/FormModel.scala
+++ b/app/uk/gov/hmrc/gform/models/FormModel.scala
@@ -19,9 +19,12 @@ package uk.gov.hmrc.gform.models
 import cats.data.NonEmptyList
 import cats.syntax.eq._
 import uk.gov.hmrc.gform.eval.{ AllPageModelExpressions, ExprMetadata, ExprType, RevealingChoiceInfo, StandaloneSumInfo, StaticTypeData, StaticTypeInfo, SumInfo, TypeInfo }
+import uk.gov.hmrc.gform.models.FormModel.modelComponentsToIndexedComponentMap
 import uk.gov.hmrc.gform.models.ids.{ BaseComponentId, IndexedComponentId, ModelComponentId, ModelPageId, MultiValueId }
 import uk.gov.hmrc.gform.sharedmodel.DataRetrieve
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+
+import scala.collection.mutable
 
 case class FormModel[A <: PageMode](
   brackets: BracketsWithSectionNumber[A],
@@ -109,9 +112,8 @@ case class FormModel[A <: PageMode](
       fc.modelComponentId
     }.toSet
 
-  def allIndexedComponentIds: List[ModelComponentId] = allFormComponents.map(_.modelComponentId).collect {
-    case mcId if mcId.indexedComponentId.isIndexed => mcId
-  }
+  def allIndexedComponentIds: Map[BaseComponentId, List[ModelComponentId]] =
+    modelComponentsToIndexedComponentMap(allFormComponents.map(_.modelComponentId))
 
   val allMultiSelectionIds: Set[ModelComponentId] = allFormComponents
     .collect {
@@ -370,6 +372,24 @@ case class FormModel[A <: PageMode](
 }
 
 object FormModel {
+
+  def modelComponentsToIndexedComponentMap(
+    modelComponentList: List[ModelComponentId]
+  ): Map[BaseComponentId, List[ModelComponentId]] = {
+    val map: mutable.Map[BaseComponentId, mutable.ListBuffer[ModelComponentId]] = mutable.Map.empty
+    modelComponentList.foreach {
+      case mcId if mcId.indexedComponentId.isIndexed =>
+        val bcId = mcId.baseComponentId
+        val l = map.getOrElse(bcId, mutable.ListBuffer.empty).addOne(mcId)
+        map.addOne((bcId, l))
+      case _ => ()
+    }
+    map
+      .foldLeft(Map.newBuilder[BaseComponentId, List[ModelComponentId]]) { case (builder, (bcId, lmcId)) =>
+        builder.addOne((bcId, lmcId.toList))
+      }
+      .result()
+  }
 
   def fromEnrolmentSection[A <: PageMode](enrolmentSection: EnrolmentSection): FormModel[A] = {
     val singleton = Singleton(enrolmentSection.toPage).asInstanceOf[Singleton[A]]

--- a/app/uk/gov/hmrc/gform/models/OptionDataUtils.scala
+++ b/app/uk/gov/hmrc/gform/models/OptionDataUtils.scala
@@ -153,8 +153,7 @@ object OptionDataUtils {
     fmvo: FormModelVisibilityOptics[D]
   ): NonEmptyList[A] = {
     val modelComponentIds =
-      fmvo.formModel.allIndexedComponentIds
-        .filter(_.baseComponentId == dynamic.formComponentId.baseComponentId)
+      fmvo.formModel.allIndexedComponentIds.get(dynamic.formComponentId.baseComponentId).toList.flatten
 
     NonEmptyList.fromList(modelComponentIds) match {
       case None => NonEmptyList.one(valueBased)

--- a/app/uk/gov/hmrc/gform/models/TableUtils.scala
+++ b/app/uk/gov/hmrc/gform/models/TableUtils.scala
@@ -80,8 +80,7 @@ object TableUtils {
     fmvo: FormModelVisibilityOptics[D]
   ): NonEmptyList[TableValueRow] = {
     val modelComponentIds =
-      fmvo.formModel.allIndexedComponentIds
-        .filter(_.baseComponentId == dynamic.formComponentId.baseComponentId)
+      fmvo.formModel.allIndexedComponentIds.get(dynamic.formComponentId.baseComponentId).toList.flatten
 
     NonEmptyList.fromList(modelComponentIds) match {
       case None => NonEmptyList.one(tableValueRow)

--- a/app/uk/gov/hmrc/gform/sharedmodel/form/FormModelOptics.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/form/FormModelOptics.scala
@@ -76,7 +76,7 @@ object FormModelOptics {
         Map.empty,
         lang,
         messages,
-        List.empty,
+        Map.empty,
         Set.empty[BaseComponentId],
         FileSizeLimit(cache.formTemplate.fileSizeLimit.getOrElse(FileSizeLimit.defaultFileLimitSize)),
         DataRetrieveAll.empty,

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val microservice = (project in file("."))
       "views.html.helper.CSPNonce"
     ),
     scalacOptions ++= Seq(
-      //"-Xfatal-warnings",
+      "-Xfatal-warnings",
       "-Xlint:-missing-interpolator,_",
       "-Xlint:-byname-implicit",
       "-Ywarn-numeric-widen",

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val microservice = (project in file("."))
       "views.html.helper.CSPNonce"
     ),
     scalacOptions ++= Seq(
-      "-Xfatal-warnings",
+      //"-Xfatal-warnings",
       "-Xlint:-missing-interpolator,_",
       "-Xlint:-byname-implicit",
       "-Ywarn-numeric-widen",

--- a/test/uk/gov/hmrc/gform/eval/EvaluationResultsSpec.scala
+++ b/test/uk/gov/hmrc/gform/eval/EvaluationResultsSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.gform.eval.ExpressionResult.{ AddressResult, DateResult, Empt
 import uk.gov.hmrc.gform.graph.RecData
 import uk.gov.hmrc.gform.lookup.ShowAll.Enabled
 import uk.gov.hmrc.gform.lookup._
-import uk.gov.hmrc.gform.models.DataRetrieveAll
+import uk.gov.hmrc.gform.models.{ DataRetrieveAll, FormModel }
 import uk.gov.hmrc.gform.models.ExpandUtils.toModelComponentId
 import uk.gov.hmrc.gform.models.ids.{ BaseComponentId, ModelComponentId, ModelPageId }
 import uk.gov.hmrc.gform.sharedmodel.SourceOrigin.OutOfDate
@@ -85,7 +85,7 @@ class EvaluationResultsSpec extends Spec with TableDrivenPropertyChecks {
           )
         )
       ),
-      indexedComponentIds,
+      FormModel.modelComponentsToIndexedComponentMap(indexedComponentIds),
       Set.empty,
       FileSizeLimit(1),
       DataRetrieveAll.empty,
@@ -906,7 +906,9 @@ class EvaluationResultsSpec extends Spec with TableDrivenPropertyChecks {
       (
         TypeInfo(Sum(FormCtx(FormComponentId("addToListQuestion"))), StaticTypeData(ExprType.number, None)),
         recData,
-        evaluationContext.copy(indexedComponentIds = List(toModelComponentId("1_addToListQuestion"))),
+        evaluationContext.copy(indexedComponentIds =
+          FormModel.modelComponentsToIndexedComponentMap(List(toModelComponentId("1_addToListQuestion")))
+        ),
         NumberResult(1),
         Map[Expr, ExpressionResult](
           FormCtx(FormComponentId("1_addToListQuestion")) -> NumberResult(0),

--- a/test/uk/gov/hmrc/gform/eval/smartstring/RealSmartStringEvaluatorFactorySpec.scala
+++ b/test/uk/gov/hmrc/gform/eval/smartstring/RealSmartStringEvaluatorFactorySpec.scala
@@ -498,7 +498,7 @@ class RealSmartStringEvaluatorFactorySpec
           Map.empty,
           LangADT.En,
           messages,
-          indexedComponentIds,
+          FormModel.modelComponentsToIndexedComponentMap(indexedComponentIds),
           Set.empty,
           FileSizeLimit(1),
           DataRetrieveAll.empty,

--- a/test/uk/gov/hmrc/gform/gform/NewFormControllerSpec.scala
+++ b/test/uk/gov/hmrc/gform/gform/NewFormControllerSpec.scala
@@ -555,7 +555,7 @@ class NewFormControllerSpec
             Map.empty,
             LangADT.En,
             messages,
-            List.empty,
+            Map.empty,
             Set.empty,
             FileSizeLimit(1),
             DataRetrieveAll.empty,

--- a/test/uk/gov/hmrc/gform/graph/RecalculationSpec.scala
+++ b/test/uk/gov/hmrc/gform/graph/RecalculationSpec.scala
@@ -69,7 +69,7 @@ class RecalculationSpec extends AnyFlatSpecLike with Matchers with GraphSpec wit
       Map.empty,
       lang,
       messages,
-      List.empty,
+      Map.empty,
       Set.empty,
       FileSizeLimit(1),
       DataRetrieveAll.empty,

--- a/test/uk/gov/hmrc/gform/services/SectionRenderingServiceSpec.scala
+++ b/test/uk/gov/hmrc/gform/services/SectionRenderingServiceSpec.scala
@@ -125,7 +125,7 @@ class SectionRenderingServiceSpec extends Spec with ArgumentMatchersSugar with I
           Map.empty,
           LangADT.En,
           messages,
-          List.empty,
+          Map.empty,
           Set.empty,
           FileSizeLimit(1),
           DataRetrieveAll.empty,

--- a/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
@@ -79,7 +79,7 @@ trait ExampleEvaluationContext {
       Map.empty,
       LangADT.En,
       Helpers.stubMessages(Helpers.stubMessagesApi(Map.empty)),
-      List.empty,
+      Map.empty,
       Set.empty,
       FileSizeLimit(1),
       DataRetrieveAll.empty,

--- a/test/uk/gov/hmrc/gform/summary/SummaryRenderingServiceSpec.scala
+++ b/test/uk/gov/hmrc/gform/summary/SummaryRenderingServiceSpec.scala
@@ -142,7 +142,7 @@ class SummaryRenderingServiceSpec
           Map.empty,
           LangADT.En,
           messages,
-          List.empty,
+          Map.empty,
           Set.empty,
           FileSizeLimit(1),
           DataRetrieveAll.empty,


### PR DESCRIPTION
Changes made:
1. Removed ExprType.fold abstraction. Abstraction had only 1 use-case, had a potentially negative impact on performance with no benefit to code structure.
2. Changed EvaluationContext.indexedComponentIds type from List[ModelComponentId] to Map[BaseComponentId, List[ModelComponentId]] to improve efficiency of data retrieval (only use-case for this). Time complexity improved from O(n) to O(1).