### PR TITLE
GFORMS-3536 - Expressions toolbox page should display error...

### DIFF
--- a/app/uk/gov/hmrc/gform/testonly/snapshot/ExpressionsLookup.scala
+++ b/app/uk/gov/hmrc/gform/testonly/snapshot/ExpressionsLookup.scala
@@ -22,7 +22,8 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ BooleanExpr, BooleanExprId, 
 
 final case class ExpressionsLookup(
   expressions: Map[ExpressionId, Expr],
-  booleanExpressions: Map[BooleanExprId, BooleanExpr]
+  booleanExpressions: Map[BooleanExprId, BooleanExpr],
+  errorMap: Map[ExpressionId, String]
 )
 
 object ExpressionsLookup {
@@ -30,5 +31,7 @@ object ExpressionsLookup {
     JsonUtils.formatMap(ExpressionId.apply, _.id)
   implicit val booleanExprMapFormat: Format[Map[BooleanExprId, BooleanExpr]] =
     JsonUtils.formatMap(BooleanExprId.apply, _.id)
+  implicit val errorMapFormat: Format[Map[ExpressionId, String]] =
+    JsonUtils.formatMap(ExpressionId.apply, _.id)
   implicit val format: Format[ExpressionsLookup] = derived.oformat()
 }


### PR DESCRIPTION
…when non-existent boolean expr is used in Expression evaluation