### PR TITLE
GFORMS-3648 - Only forms with 'email' auth config allowed (production…

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/SaveAcknowledgementController.scala
+++ b/app/uk/gov/hmrc/gform/gform/SaveAcknowledgementController.scala
@@ -98,7 +98,9 @@ class SaveAcknowledgementController(
           }
           .pure[Future]
       case _ =>
-        throw new IllegalArgumentException(s"Only forms with 'email' auth config allowed")
+        throw new IllegalArgumentException(
+          s"Only forms with 'email' auth config allowed. Received $config. FormTemplateId: $formTemplateId"
+        )
     }
   }
 


### PR DESCRIPTION
… issue)