### PR TITLE
GFORMS-3643 - Eliminate side effects from recalculation logic - make it pure

### DIFF
--- a/app/uk/gov/hmrc/gform/controllers/AuthenticatedRequestActions.scala
+++ b/app/uk/gov/hmrc/gform/controllers/AuthenticatedRequestActions.scala
@@ -17,21 +17,19 @@
 package uk.gov.hmrc.gform
 package controllers
 
-import cats.Id
+import cats.syntax.all._
 import cats.data.NonEmptyList
 import cats.instances.future._
-import cats.syntax.applicative._
-import cats.syntax.eq._
 import com.softwaremill.quicklens._
-import java.time.LocalDate
 import org.slf4j.LoggerFactory
 import play.api.i18n.{ I18nSupport, Langs, Messages, MessagesApi }
 import play.api.mvc.Results._
 import play.api.mvc._
+import scalax.collection.immutable.Graph
 import shapeless.syntax.typeable._
 import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.{ Credentials, ItmpAddress, ItmpName }
 import uk.gov.hmrc.auth.core.retrieve.v2._
+import uk.gov.hmrc.auth.core.retrieve.{ Credentials, ItmpAddress, ItmpName }
 import uk.gov.hmrc.auth.core.{ InsufficientEnrolments, AuthConnector => _, _ }
 import uk.gov.hmrc.gform.auth._
 import uk.gov.hmrc.gform.auth.models._
@@ -39,20 +37,20 @@ import uk.gov.hmrc.gform.commons.MarkDownUtil
 import uk.gov.hmrc.gform.config.AppConfig
 import uk.gov.hmrc.gform.controllers.GformSessionKeys.REFERRER_CHECK_DETAILS
 import uk.gov.hmrc.gform.eval.smartstring.{ SmartStringEvaluator, SmartStringEvaluatorFactory }
-import uk.gov.hmrc.gform.eval.{ DbLookupChecker, DelegatedEnrolmentChecker, SeissEligibilityChecker }
 import uk.gov.hmrc.gform.gform.SessionUtil.jsonFromSession
 import uk.gov.hmrc.gform.gformbackend.GformConnector
-import uk.gov.hmrc.gform.graph.{ GraphException, Recalculation }
 import uk.gov.hmrc.gform.lookup.LookupRegistry
 import uk.gov.hmrc.gform.models._
 import uk.gov.hmrc.gform.models.optics.DataOrigin
 import uk.gov.hmrc.gform.models.userdetails.Nino
 import uk.gov.hmrc.gform.sharedmodel.form._
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.sharedmodel.graph.{ GraphDataCache, GraphDataCacheService }
 import uk.gov.hmrc.gform.sharedmodel.{ AffinityGroup, _ }
 import uk.gov.hmrc.http.{ HeaderCarrier, SessionKeys }
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
+import java.time.LocalDate
 import java.util.UUID
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -88,9 +86,9 @@ class AuthenticatedRequestActions(
   langs: Langs,
   actionBuilder: ActionBuilder[Request, AnyContent],
   errResponder: ErrResponder,
-  recalculation: Recalculation[Future, Throwable],
   smartStringEvaluatorFactory: SmartStringEvaluatorFactory,
-  lookupRegistry: LookupRegistry
+  lookupRegistry: LookupRegistry,
+  graphDataService: GraphDataCacheService
 )(implicit
   ec: ExecutionContext,
   messagesApi: MessagesApi
@@ -409,7 +407,7 @@ class AuthenticatedRequestActions(
     )
 
     def whenFormExists(form: Form): Future[Result] =
-      for {
+      (for {
         _ <- MDCHelpers.addFormIdToMdc(form._id)
         formTemplateForForm <- if (form.formTemplateId === formTemplate._id)
                                  formTemplateContext.formTemplate.pure[Future]
@@ -417,34 +415,66 @@ class AuthenticatedRequestActions(
         specimenSource <- if (formTemplateForForm.isSpecimen) {
                             gformConnector.getFormTemplate(noSpecimen(formTemplateForForm._id)).map(Some(_))
                           } else None.pure[Future]
-        formUpd = if (form.status === Submitted) {
-                    form.copy(formTemplateId = formTemplate._id)
-                  } else form
-        cache = AuthCacheWithForm(
-                  retrievals,
-                  formUpd,
-                  FormTemplateContext.basicContext(formTemplateForForm, specimenSource),
-                  role,
-                  maybeAccessCode,
-                  lookupRegistry
-                )
+      } yield {
 
-        formModelOptics <-
-          FormModelOptics
-            .mkFormModelOptics[DataOrigin.Mongo, Future, U](cache.variadicFormData, cache, recalculation)
+        val formTemplateContext = FormTemplateContext.basicContext(formTemplateForForm, specimenSource)
+        val formTemplate = formTemplateContext.formTemplate
 
-        formModelOpticsUpd =
-          formModelOptics
-            .modify(_.formModelVisibilityOptics.recalculationResult.evaluationContext.formTemplateId)
-            .setTo(formUpd.formTemplateId)
+        val formUpd = if (form.status === Submitted) {
+          form.copy(formTemplateId = formTemplate._id)
+        } else form
 
-        smartStringEvaluator =
-          smartStringEvaluatorFactory
-            .apply(
-              formModelOpticsUpd.formModelVisibilityOptics
-            )
-        result <- f(cache)(smartStringEvaluator)(formModelOptics)
-      } yield result
+        val cacheData: CacheData = new CacheData(
+          form.envelopeId,
+          form.thirdPartyData,
+          formTemplate
+        )
+
+        val fmb = new FormModelBuilder(
+          retrievals,
+          formTemplate,
+          cacheData.thirdPartyData,
+          cacheData.envelopeId,
+          maybeAccessCode,
+          form.componentIdToFileId,
+          lookupRegistry,
+          form.taskIdTaskStatus
+        )
+
+        val variadicFormData: VariadicFormData[SourceOrigin.OutOfDate] =
+          VariadicFormData.buildFromMongoData(fmb.dependencyGraphValidation, form.formData.toData)
+        graphDataService.get(retrievals, variadicFormData, formTemplate, fmb).flatMap { graphData =>
+          val cache = AuthCacheWithForm(
+            retrievals,
+            formUpd,
+            formTemplateContext,
+            role,
+            maybeAccessCode,
+            lookupRegistry,
+            graphData
+          )
+
+          val formModelOptics =
+            FormModelOptics
+              .mkFormModelOptics[DataOrigin.Mongo, U](
+                cache.variadicFormData,
+                cache
+              )
+
+          val formModelOpticsUpd =
+            formModelOptics
+              .modify(_.formModelVisibilityOptics.recalculationResult.evaluationContext.formTemplateId)
+              .setTo(formUpd.formTemplateId)
+
+          val smartStringEvaluator =
+            smartStringEvaluatorFactory
+              .apply(
+                formModelOpticsUpd.formModelVisibilityOptics
+              )
+
+          f(cache)(smartStringEvaluator)(formModelOptics)
+        }
+      }).flatten
 
     val formIdData = FormIdData(retrievals, formTemplate._id, maybeAccessCode)
 
@@ -610,30 +640,23 @@ case class AuthCacheWithForm(
   formTemplateContext: FormTemplateContext,
   role: Role,
   accessCode: Option[AccessCode],
-  lookupRegistry: LookupRegistry
+  lookupRegistry: LookupRegistry,
+  graphData: GraphDataCache
 ) extends AuthCache {
   val formTemplate: FormTemplate = formTemplateContext.formTemplate
   val formTemplateId: FormTemplateId = formTemplate._id
   def formModel[U <: SectionSelectorType: SectionSelector](implicit
     hc: HeaderCarrier
-  ): FormModel[DependencyGraphVerification] = {
-    import uk.gov.hmrc.gform.typeclasses.identityThrowableMonadError
+  ): FormModel[DependencyGraphVerification] =
     FormModelBuilder
       .fromCache(
         this,
         toCacheData,
-        new Recalculation[Id, Throwable](
-          SeissEligibilityChecker.alwaysEligible,
-          DelegatedEnrolmentChecker.alwaysDelegated,
-          DbLookupChecker.alwaysPresent,
-          (s: GraphException) => new IllegalArgumentException(s.reportProblem)
-        ),
         form.componentIdToFileId,
         lookupRegistry,
         form.taskIdTaskStatus
       )
       .dependencyGraphValidation
-  }
 
   def toCacheData: CacheData = new CacheData(
     form.envelopeId,
@@ -669,6 +692,7 @@ case class AuthCacheWithoutForm(
     ThirdPartyData.empty,
     formTemplate
   )
+  val graphDataCache = GraphDataCache(Graph.empty, in => false)
   def toAuthCacheWithForm(form: Form, accessCode: Option[AccessCode]) =
     AuthCacheWithForm(
       retrievals,
@@ -679,7 +703,8 @@ case class AuthCacheWithoutForm(
       FormTemplateContext.basicContext(formTemplate, None),
       role,
       accessCode,
-      lookupRegistry
+      lookupRegistry,
+      graphDataCache
     )
 }
 

--- a/app/uk/gov/hmrc/gform/controllers/ControllersModule.scala
+++ b/app/uk/gov/hmrc/gform/controllers/ControllersModule.scala
@@ -57,9 +57,9 @@ class ControllersModule(
     playBuiltInsModule.langs,
     builtInComponents.defaultActionBuilder,
     errResponder,
-    graphModule.recalculation,
     graphModule.smartStringEvaluatorFactory,
-    lookupRegistry
+    lookupRegistry,
+    graphModule.graphDataCacheService
   )
 
   val messagesControllerComponents: MessagesControllerComponents = DefaultMessagesControllerComponents(

--- a/app/uk/gov/hmrc/gform/eval/BooleanExprEval.scala
+++ b/app/uk/gov/hmrc/gform/eval/BooleanExprEval.scala
@@ -94,12 +94,10 @@ class BooleanExprEval[F[_]: Monad] {
 
         l.contains(r).pure[F]
 
-      case in @ In(_, _) =>
-        val formModel = formModelVisibilityOptics.formModel
+      case in: In =>
         val recalculationResult = formModelVisibilityOptics.recalculationResult
-        val recData = formModelVisibilityOptics.recData
         BooleanExprEval
-          .evalInExpr(in, formModel, recalculationResult, formModelVisibilityOptics.booleanExprResolver, recData)
+          .evalInExpr(in, recalculationResult)
           .pure[F]
 
       case h @ HasAnswer(_, _) =>
@@ -227,20 +225,11 @@ object BooleanExprEval {
 
   def evalInExpr[T <: PageMode](
     in: In,
-    formModel: FormModel[T],
-    recalculationResult: RecalculationResult,
-    booleanExprResolver: BooleanExprResolver,
-    recData: RecData[SourceOrigin.Current]
+    recalculationResult: RecalculationResult
   ): Boolean = {
-    val typeInfo = formModel.toFirstOperandTypeInfo(in.value)
-    val expressionResult = recalculationResult.evaluationResults
-      .evalExprCurrent(typeInfo, recData, booleanExprResolver, recalculationResult.evaluationContext)
-    val maybeBoolean =
-      recalculationResult.booleanExprCache.get(
-        in.dataSource,
-        expressionResult.stringRepresentation(typeInfo, recalculationResult.evaluationContext.messages)
-      )
-    maybeBoolean.getOrElse(false)
+    println(in)
+    println(recalculationResult.inExprResolver(in))
+    recalculationResult.inExprResolver(in)
   }
 
   def evalFirstExpr[T <: PageMode](

--- a/app/uk/gov/hmrc/gform/eval/BooleanExprEval.scala
+++ b/app/uk/gov/hmrc/gform/eval/BooleanExprEval.scala
@@ -226,9 +226,8 @@ object BooleanExprEval {
   def evalInExpr[T <: PageMode](
     in: In,
     recalculationResult: RecalculationResult
-  ): Boolean = {
-    recalculationResult.inExprResolver(in)
-  }
+  ): Boolean =
+    recalculationResult.graphDataCache.inExprResolver(in)
 
   def evalFirstExpr[T <: PageMode](
     formComponentId: FormComponentId

--- a/app/uk/gov/hmrc/gform/eval/BooleanExprEval.scala
+++ b/app/uk/gov/hmrc/gform/eval/BooleanExprEval.scala
@@ -227,8 +227,6 @@ object BooleanExprEval {
     in: In,
     recalculationResult: RecalculationResult
   ): Boolean = {
-    println(in)
-    println(recalculationResult.inExprResolver(in))
     recalculationResult.inExprResolver(in)
   }
 

--- a/app/uk/gov/hmrc/gform/eval/DbLookupChecker.scala
+++ b/app/uk/gov/hmrc/gform/eval/DbLookupChecker.scala
@@ -16,17 +16,13 @@
 
 package uk.gov.hmrc.gform.eval
 
-import cats.Id
-import cats.syntax.applicative._
 import uk.gov.hmrc.gform.sharedmodel.dblookup.CollectionName
 import uk.gov.hmrc.http.HeaderCarrier
 
-class DbLookupChecker[F[_]](dbLookupStatus: (String, CollectionName, HeaderCarrier) => F[Boolean])
-    extends Function3[String, CollectionName, HeaderCarrier, F[Boolean]] {
-  def apply(value: String, collectionName: CollectionName, hc: HeaderCarrier): F[Boolean] =
-    dbLookupStatus(value, collectionName, hc)
-}
+import scala.concurrent.Future
 
-object DbLookupChecker {
-  val alwaysPresent: DbLookupChecker[Id] = new DbLookupChecker[Id]((_, _, _) => true.pure[Id])
+class DbLookupChecker(dbLookupStatus: (String, CollectionName, HeaderCarrier) => Future[Boolean])
+    extends Function3[String, CollectionName, HeaderCarrier, Future[Boolean]] {
+  def apply(value: String, collectionName: CollectionName, hc: HeaderCarrier): Future[Boolean] =
+    dbLookupStatus(value, collectionName, hc)
 }

--- a/app/uk/gov/hmrc/gform/eval/DelegatedEnrolmentChecker.scala
+++ b/app/uk/gov/hmrc/gform/eval/DelegatedEnrolmentChecker.scala
@@ -16,24 +16,25 @@
 
 package uk.gov.hmrc.gform.eval
 
-import cats.Id
-import cats.syntax.applicative._
 import uk.gov.hmrc.gform.auth.models.{ GovernmentGatewayId, IdentifierValue }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.DataSource.DelegatedEnrolment
 import uk.gov.hmrc.http.HeaderCarrier
 
-class DelegatedEnrolmentChecker[F[_]](
-  delegatedEnrolmentCheckStatus: (GovernmentGatewayId, DelegatedEnrolment, IdentifierValue, HeaderCarrier) => F[Boolean]
-) extends Function4[GovernmentGatewayId, DelegatedEnrolment, IdentifierValue, HeaderCarrier, F[Boolean]] {
+import scala.concurrent.Future
+
+class DelegatedEnrolmentChecker(
+  delegatedEnrolmentCheckStatus: (
+    GovernmentGatewayId,
+    DelegatedEnrolment,
+    IdentifierValue,
+    HeaderCarrier
+  ) => Future[Boolean]
+) extends Function4[GovernmentGatewayId, DelegatedEnrolment, IdentifierValue, HeaderCarrier, Future[Boolean]] {
   def apply(
     governmentGatewayId: GovernmentGatewayId,
     delegatedEnrolment: DelegatedEnrolment,
     identifierValue: IdentifierValue,
     hc: HeaderCarrier
-  ): F[Boolean] =
+  ): Future[Boolean] =
     delegatedEnrolmentCheckStatus(governmentGatewayId, delegatedEnrolment, identifierValue, hc)
-}
-
-object DelegatedEnrolmentChecker {
-  val alwaysDelegated: DelegatedEnrolmentChecker[Id] = new DelegatedEnrolmentChecker[Id]((_, _, _, _) => true.pure[Id])
 }

--- a/app/uk/gov/hmrc/gform/eval/SeissEligibilityChecker.scala
+++ b/app/uk/gov/hmrc/gform/eval/SeissEligibilityChecker.scala
@@ -16,16 +16,12 @@
 
 package uk.gov.hmrc.gform.eval
 
-import cats.Id
-import cats.syntax.applicative._
 import uk.gov.hmrc.gform.auth.UtrEligibilityRequest
 import uk.gov.hmrc.http.HeaderCarrier
 
-class SeissEligibilityChecker[F[_]](checkEligibility: (UtrEligibilityRequest, HeaderCarrier) => F[Boolean])
-    extends Function2[UtrEligibilityRequest, HeaderCarrier, F[Boolean]] {
-  def apply(request: UtrEligibilityRequest, hc: HeaderCarrier): F[Boolean] = checkEligibility(request, hc)
-}
+import scala.concurrent.Future
 
-object SeissEligibilityChecker {
-  val alwaysEligible: SeissEligibilityChecker[Id] = new SeissEligibilityChecker[Id]((_, _) => true.pure[Id])
+class SeissEligibilityChecker(checkEligibility: (UtrEligibilityRequest, HeaderCarrier) => Future[Boolean])
+    extends Function2[UtrEligibilityRequest, HeaderCarrier, Future[Boolean]] {
+  def apply(request: UtrEligibilityRequest, hc: HeaderCarrier): Future[Boolean] = checkEligibility(request, hc)
 }

--- a/app/uk/gov/hmrc/gform/gform/DeclarationController.scala
+++ b/app/uk/gov/hmrc/gform/gform/DeclarationController.scala
@@ -151,7 +151,6 @@ class DeclarationController(
             .getProcessData[SectionSelectorType.WithDeclaration](
               variadicFormData,
               cache,
-              formModelOptics,
               gformConnector.getAllTaxPeriods,
               NoSpecificAction
             )

--- a/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
+++ b/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
@@ -233,7 +233,9 @@ class FastForwardService(
                    processData.visitsIndex,
                    cache.form.thirdPartyData
                      .modify(_.obligations)
-                     .setTo(processData.obligations),
+                     .setTo(processData.obligations)
+                     .modify(_.booleanExprCache)
+                     .setTo(processData.booleanExprCache),
                    cache.form.componentIdToFileId,
                    cache.form.taskIdTaskStatus
                  )

--- a/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
+++ b/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
@@ -109,7 +109,7 @@ class FastForwardService(
     l: LangADT
   ): Future[Result] =
     processDataService
-      .getProcessData(cache.variadicFormData, cache, formModelOptics, gformConnector.getAllTaxPeriods, ForceReload)
+      .getProcessData(cache.variadicFormData, cache, gformConnector.getAllTaxPeriods, ForceReload)
       .flatMap { processData =>
         // This formModelVisibilityOptics comes from Mongo, not from Browser
         val formModelVisibilityOptics: FormModelVisibilityOptics[DataOrigin.Browser] =
@@ -260,7 +260,6 @@ class FastForwardService(
                        formModelOptics.formModelRenderPageOptics.recData.variadicFormData
                          .asInstanceOf[VariadicFormData[SourceOrigin.OutOfDate]],
                        cache,
-                       formModelOptics,
                        gformConnector.getAllTaxPeriods,
                        NoSpecificAction
                      )

--- a/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
+++ b/app/uk/gov/hmrc/gform/gform/FastForwardService.scala
@@ -233,9 +233,7 @@ class FastForwardService(
                    processData.visitsIndex,
                    cache.form.thirdPartyData
                      .modify(_.obligations)
-                     .setTo(processData.obligations)
-                     .modify(_.booleanExprCache)
-                     .setTo(processData.booleanExprCache),
+                     .setTo(processData.obligations),
                    cache.form.componentIdToFileId,
                    cache.form.taskIdTaskStatus
                  )

--- a/app/uk/gov/hmrc/gform/gform/FormAddToListController.scala
+++ b/app/uk/gov/hmrc/gform/gform/FormAddToListController.scala
@@ -233,7 +233,6 @@ class FormAddToListController(
                          formModelOptics.formModelRenderPageOptics.recData.variadicFormData
                            .asInstanceOf[VariadicFormData[OutOfDate]],
                          cache,
-                         formModelOptics,
                          gformConnector.getAllTaxPeriods,
                          NoSpecificAction
                        )

--- a/app/uk/gov/hmrc/gform/gform/GformModule.scala
+++ b/app/uk/gov/hmrc/gform/gform/GformModule.scala
@@ -85,7 +85,6 @@ class GformModule(
     sectionRenderingService,
     validationModule.validationService,
     authModule.enrolmentService,
-    graphModule.recalculation,
     authModule.taxEnrolmentsConnector,
     authModule.ggConnector,
     configModule.frontendAppConfig,
@@ -99,7 +98,7 @@ class GformModule(
   }
 
   val processDataService: ProcessDataService[Future] =
-    new ProcessDataService[Future](graphModule.recalculation, taxPeriodStateChecker)
+    new ProcessDataService[Future](taxPeriodStateChecker)
 
   val formControllerRequestHandler = new FormControllerRequestHandler(new FormValidator())
 
@@ -181,7 +180,6 @@ class GformModule(
     fileSystemConnector,
     validationModule.validationService,
     fastForwardService,
-    graphModule.recalculation,
     objectStoreModule.objectStoreService,
     formControllerRequestHandler,
     bankAccountReputationConnector,
@@ -210,7 +208,6 @@ class GformModule(
     processDataService,
     formControllerRequestHandler,
     fastForwardService,
-    graphModule.recalculation,
     addToListProcessor,
     confirmationService,
     controllersModule.messagesControllerComponents,
@@ -252,8 +249,7 @@ class GformModule(
     sectionRenderingService,
     pdfRenderService,
     lookupRegistry,
-    graphModule.smartStringEvaluatorFactory,
-    graphModule.recalculation
+    graphModule.smartStringEvaluatorFactory
   )
 
   val nonRepudiationHelpers = new NonRepudiationHelpers(auditingModule)
@@ -350,7 +346,6 @@ class GformModule(
     gformBackendModule.gformConnector,
     fastForwardService,
     auditingModule.auditService,
-    graphModule.recalculation,
     controllersModule.messagesControllerComponents,
     gformBackEndService,
     ninoInsightsConnector,
@@ -437,7 +432,6 @@ class GformModule(
       configModule.frontendAppConfig,
       playBuiltInsModule.i18nSupport,
       controllersModule.messagesControllerComponents,
-      graphModule.recalculation,
       formControllerRequestHandler,
       validationModule.validationService,
       fastForwardService,

--- a/app/uk/gov/hmrc/gform/graph/GraphModule.scala
+++ b/app/uk/gov/hmrc/gform/graph/GraphModule.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.gform.graph
 
 import cats.instances.future._
+
 import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.gform.auth.AuthModule
 import uk.gov.hmrc.gform.eval.{ BooleanExprEval, DbLookupChecker, DelegatedEnrolmentChecker }
@@ -24,6 +25,7 @@ import uk.gov.hmrc.gform.eval.SeissEligibilityChecker
 import uk.gov.hmrc.gform.eval.smartstring.{ RealSmartStringEvaluatorFactory, SmartStringEvaluatorFactory }
 import uk.gov.hmrc.gform.gformbackend.GformBackendModule
 import play.api.i18n.Messages
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCacheService
 
 class GraphModule(
   authModule: AuthModule,
@@ -42,14 +44,11 @@ class GraphModule(
 
   val dbLookupCheckStatus = new DbLookupChecker(gformBackendModule.gformConnector.dbLookup)
 
-  private val graphErrorHandler = (s: GraphException) => new IllegalArgumentException(s.reportProblem)
-
-  val recalculation: Recalculation[Future, Throwable] =
-    new Recalculation(seissEligibilityChecker, delegatedEnrolmentCheckStatus, dbLookupCheckStatus, graphErrorHandler)
-
   val smartStringEvaluatorFactory: SmartStringEvaluatorFactory =
     new RealSmartStringEvaluatorFactory(englishMessages)
 
   val booleanExprEval: BooleanExprEval[Future] = new BooleanExprEval()
 
+  val graphDataCacheService: GraphDataCacheService =
+    new GraphDataCacheService(seissEligibilityChecker, delegatedEnrolmentCheckStatus, dbLookupCheckStatus)
 }

--- a/app/uk/gov/hmrc/gform/graph/Recalculation.scala
+++ b/app/uk/gov/hmrc/gform/graph/Recalculation.scala
@@ -95,7 +95,7 @@ object Recalculation {
           startEvResults,
           GraphData(graphTopologicalOrder, graphDataCache.graph),
           evaluationContext,
-          graphDataCache.inExprResolver
+          graphDataCache
         )
     }
   }

--- a/app/uk/gov/hmrc/gform/graph/Recalculation.scala
+++ b/app/uk/gov/hmrc/gform/graph/Recalculation.scala
@@ -241,8 +241,6 @@ object Recalculation {
     inExprResolver: In => Boolean
   )(implicit formModel: FormModel[Interim]): Boolean = {
 
-    //TODO: Instead of using this resolver, evalBooleanExpr should be a tail recursion optimized function.
-    //TODO: This would optimize memory usage for deep expression chains.
     val booleanExprResolver = BooleanExprResolver { booleanExpr =>
       evalBooleanExpr(booleanExpr, evaluationResults, recData, retrievals, evaluationContext, inExprResolver)
     }

--- a/app/uk/gov/hmrc/gform/graph/Recalculation.scala
+++ b/app/uk/gov/hmrc/gform/graph/Recalculation.scala
@@ -17,21 +17,17 @@
 package uk.gov.hmrc.gform.graph
 
 import cats.syntax.all._
-import cats.{ Monad, MonadError }
 import play.api.i18n.Messages
 import scalax.collection.edges.DiEdge
 import scalax.collection.immutable.Graph
-import uk.gov.hmrc.gform.auth.UtrEligibilityRequest
-import uk.gov.hmrc.gform.auth.models.{ IdentifierValue, MaterialisedRetrievals }
+import uk.gov.hmrc.gform.auth.models.MaterialisedRetrievals
 import uk.gov.hmrc.gform.eval._
 import uk.gov.hmrc.gform.models.ids.ModelComponentId
 import uk.gov.hmrc.gform.models.{ FormModel, Interim, PageModel }
-import uk.gov.hmrc.gform.sharedmodel.SourceOrigin.OutOfDate
 import uk.gov.hmrc.gform.sharedmodel.form.ThirdPartyData
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
-import uk.gov.hmrc.gform.sharedmodel.graph.{ DependencyGraph, GraphNode }
+import uk.gov.hmrc.gform.sharedmodel.graph.{ DependencyGraph, GraphDataCache, GraphNode }
 import uk.gov.hmrc.gform.sharedmodel.{ BooleanExprCache, SourceOrigin, VariadicFormData, VariadicValue }
-
 import scala.collection.{ immutable, mutable }
 
 sealed trait GraphException {
@@ -46,12 +42,7 @@ sealed trait GraphException {
 case class NoTopologicalOrder(fcId: GraphNode, graph: Graph[GraphNode, DiEdge[GraphNode]]) extends GraphException
 case class NoFormComponent(fcId: FormComponentId, lookup: Map[FormComponentId, FormComponent]) extends GraphException
 
-class Recalculation[F[_]: Monad, E](
-  val seissEligibilityChecker: SeissEligibilityChecker[F],
-  val delegatedEnrolmentCheckStatus: DelegatedEnrolmentChecker[F],
-  val dbLookupCheckStatus: DbLookupChecker[F],
-  val error: GraphException => E
-) {
+object Recalculation {
 
   def recalculateFormDataNew(
     data: VariadicFormData[SourceOrigin.OutOfDate],
@@ -60,18 +51,15 @@ class Recalculation[F[_]: Monad, E](
     retrievals: MaterialisedRetrievals,
     thirdPartyData: ThirdPartyData,
     evaluationContext: EvaluationContext,
-    messages: Messages
-  )(implicit me: MonadError[F, E]): F[RecalculationResult] = {
+    messages: Messages,
+    graphDataCache: GraphDataCache
+  ): RecalculationResult = {
 
     implicit val fm: FormModel[Interim] = formModel
 
-    val formTemplateExprs: Set[ExprMetadata] = AllFormTemplateExpressions(formTemplate)
-
-    val graph: Graph[GraphNode, DiEdge[GraphNode]] = DependencyGraph.toGraph(formModel, formTemplateExprs)
-
     val orderedGraph: Either[GraphException, Iterable[(Int, List[GraphNode])]] = DependencyGraph
-      .constructDependencyGraph(graph)
-      .leftMap(node => NoTopologicalOrder(node.outer, graph))
+      .constructDependencyGraph(graphDataCache.graph)
+      .leftMap(node => NoTopologicalOrder(node.outer, graphDataCache.graph))
 
     val exprMap = mutable.Map[Expr, ExpressionResult]()
     val formDataMap = mutable.Map.newBuilder.addAll(data.data).result()
@@ -90,25 +78,24 @@ class Recalculation[F[_]: Monad, E](
         }
         .result()
 
-    val res: Either[GraphException, F[Iterable[(Int, List[GraphNode])]]] =
+    val res: Either[GraphException, Iterable[(Int, List[GraphNode])]] =
       for {
         graphTopologicalOrder <- orderedGraph
       } yield {
-        val recalc = graphTopologicalOrder.toList.reverse.foldLeft(().pure[F]) { case (state, (_, graphLayer)) =>
+        graphTopologicalOrder.toList.reverse.foreach { case (_, graphLayer) =>
           recalculateGraphLayer(
             graphLayer,
-            state.map(_ => startEvResults),
+            startEvResults,
             retrievals,
             evaluationContext,
             messages,
             exprMap,
             formDataMap,
-            booleanExprCacheMap
+            graphDataCache.inExprResolver
           )
         }
-        recalc.map { _ =>
-          graphTopologicalOrder
-        }
+
+        graphTopologicalOrder
       }
 
     def immutableBooleanExprCacheMap = booleanExprCacheMap
@@ -120,183 +107,162 @@ class Recalculation[F[_]: Monad, E](
       .result()
 
     res match {
-      case Left(graphException) => me.raiseError(error(graphException))
-      case Right(fd) =>
-        fd.map { graphTopologicalOrder =>
-          RecalculationResult(
-            startEvResults,
-            GraphData(graphTopologicalOrder, graph),
-            BooleanExprCache(immutableBooleanExprCacheMap),
-            evaluationContext
-          )
-
-        }
+      case Left(graphException) => throw new IllegalArgumentException(graphException.reportProblem)
+      case Right(graphTopologicalOrder) =>
+        RecalculationResult(
+          startEvResults,
+          GraphData(graphTopologicalOrder, graphDataCache.graph),
+          BooleanExprCache(immutableBooleanExprCacheMap),
+          evaluationContext
+        )
     }
   }
 
   private def recalculateGraphLayer(
     graphLayer: List[GraphNode],
-    state: F[EvaluationResults],
+    evResult: EvaluationResults,
     retrievals: MaterialisedRetrievals,
     evaluationContext: EvaluationContext,
     messages: Messages,
     exprMap: mutable.Map[Expr, ExpressionResult],
     variadicFormDataMap: mutable.Map[ModelComponentId, VariadicValue],
-    booleanExprCacheMap: mutable.Map[DataSource, mutable.Map[String, Boolean]]
-  )(implicit formModel: FormModel[Interim]): F[Unit] =
-    state.flatMap { evResult =>
-      val recData = SourceOrigin.changeSourceToOutOfDate(evResult.recData)
+    inExprResolver: In => Boolean
+  )(implicit formModel: FormModel[Interim]): Unit = {
+    val recData = SourceOrigin.changeSourceToOutOfDate(evResult.recData)
 
-      val booleanExprResolver = BooleanExprResolver { booleanExpr =>
-        evalBooleanExprPure(booleanExpr, evResult, recData, retrievals, evaluationContext)
-      }
-
-      def evalExpr(expr: Expr) = {
-        val typeInfo: TypeInfo = formModel.toFirstOperandTypeInfo(expr)
-        evResult
-          .evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
-          .applyTypeInfo(typeInfo)
-          .stringRepresentation(typeInfo, messages)
-      }
-
-      val graphLayerResult = graphLayer.traverseVoid {
-
-        case GraphNode.Simple(fcId) =>
-          val fc: Option[FormComponent] = formModel.fcLookup.get(fcId)
-          val isOptionHidden = fc.exists {
-            case IsChoice(_) | IsRevealingChoice(_) =>
-              val userResponse: Seq[String] = recData.variadicFormData.many(fcId.modelComponentId).toSeq.flatten
-              val optionData: List[OptionData] = fc
-                .collect {
-                  case IsChoice(c) =>
-                    c.options.toList.collect {
-                      case o @ OptionData.ValueBased(_, _, _, _, OptionDataValue.StringBased(value), _)
-                          if userResponse.contains(value) =>
-                        o
-                      case o @ OptionData.ValueBased(_, _, _, _, OptionDataValue.ExprBased(expr), _)
-                          if userResponse.contains(evalExpr(expr)) =>
-                        o
-                      case o: OptionData.IndexBased if userResponse.contains(o.toString) => o
-                    }
-                  case IsRevealingChoice(rc) => rc.options.map(_.choice)
-                }
-                .getOrElse(List.empty[OptionData])
-
-              val includeIfs: List[IncludeIf] = optionData.collect {
-                case OptionData.ValueBased(_, _, Some(includeIf), _, _, _) => includeIf
-                case OptionData.IndexBased(_, _, Some(includeIf), _, _)    => includeIf
-              }
-
-              val isHidden = includeIfs
-                .map(i => booleanExprResolver.resolve(i.booleanExpr))
-                .reduceOption(_ && _)
-                .getOrElse(true)
-              !isHidden
-            case _ => false
-          }
-
-          val recDataUpd: RecData[OutOfDate] =
-            if (isOptionHidden) {
-              variadicFormDataMap.remove(fcId.modelComponentId)
-              recData
-            } else {
-              recData
-            }
-
-          val res = for {
-            isHiddenIncludeIf <-
-              isHiddenByIncludeIf(
-                fcId,
-                evResult,
-                recData,
-                retrievals,
-                booleanExprResolver,
-                evaluationContext,
-                exprMap,
-                booleanExprCacheMap
-              )
-            isHiddenComponentIncludeIf <-
-              isHiddenByComponentIncludeIf(
-                fcId,
-                evResult,
-                recData,
-                retrievals,
-                booleanExprResolver,
-                evaluationContext,
-                exprMap,
-                booleanExprCacheMap
-              )
-            isHiddenRevealingChoice <- isHiddenByRevealingChoice(fcId, recData)
-            isHiddenRepeatsExpr <-
-              isHiddenByRepeatsExpr(fcId, evResult, recData, booleanExprResolver, evaluationContext)
-          } yield
-            if (isHiddenIncludeIf || isHiddenRevealingChoice || isHiddenComponentIncludeIf || isHiddenRepeatsExpr) {
-              exprMap.addOne((FormCtx(fcId), ExpressionResult.Hidden))
-              evResult
-            } else {
-              evResult
-            }
-
-          res.map(_.copy(recData = SourceOrigin.changeSource(recDataUpd)))
-
-        case GraphNode.Expr(formCtx @ FormCtx(formComponentId)) =>
-          val expr: Expr = formModel.fcLookup
-            .get(formComponentId)
-            .collect { case HasValueExpr(expr) =>
-              expr
-            }
-            .getOrElse(formCtx)
-          val typeInfo: TypeInfo = formModel.explicitTypedExpr(expr, formComponentId)
-
-          val exprResult: ExpressionResult =
-            evResult
-              .evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
-              .applyTypeInfo(typeInfo)
-          val newExpr = (
-            formCtx,
-            evResult.get(formCtx).fold(exprResult) {
-              case ExpressionResult.Hidden => ExpressionResult.Hidden // If something is Hidden keep it so.
-              case _                       => exprResult
-            }
-          )
-          exprMap.addOne(newExpr)
-          evResult.pure[F]
-
-        case GraphNode.Expr(expr) =>
-          val typeInfo: TypeInfo = formModel.toFirstOperandTypeInfo(expr)
-
-          val exprResult: ExpressionResult =
-            evResult.evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
-
-          exprMap.addOne((expr, exprResult))
-          evResult.pure[F]
-      }
-
-      // We are only interested in `ValidIf` with `In` expression and any other `validIf` is being ignored
-      evalValidIfs(
-        evResult,
-        recData,
-        retrievals,
-        booleanExprResolver,
-        evaluationContext,
-        exprMap,
-        booleanExprCacheMap
-      ) >> {
-        if (graphLayer.isEmpty) evResult.pure[F].void else graphLayerResult
-      }
-
+    val booleanExprResolver = BooleanExprResolver { booleanExpr =>
+      evalBooleanExpr(booleanExpr, evResult, recData, retrievals, evaluationContext, inExprResolver)
     }
 
-  private def evalBooleanExprPure(
+    def evalExpr(expr: Expr) = {
+      val typeInfo: TypeInfo = formModel.toFirstOperandTypeInfo(expr)
+      evResult
+        .evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
+        .applyTypeInfo(typeInfo)
+        .stringRepresentation(typeInfo, messages)
+    }
+
+    graphLayer.foreach {
+
+      case GraphNode.Simple(fcId) =>
+        val fc: Option[FormComponent] = formModel.fcLookup.get(fcId)
+        val isOptionHidden = fc.exists {
+          case IsChoice(_) | IsRevealingChoice(_) =>
+            val userResponse: Seq[String] = recData.variadicFormData.many(fcId.modelComponentId).toSeq.flatten
+            val optionData: List[OptionData] = fc
+              .collect {
+                case IsChoice(c) =>
+                  c.options.toList.collect {
+                    case o @ OptionData.ValueBased(_, _, _, _, OptionDataValue.StringBased(value), _)
+                        if userResponse.contains(value) =>
+                      o
+                    case o @ OptionData.ValueBased(_, _, _, _, OptionDataValue.ExprBased(expr), _)
+                        if userResponse.contains(evalExpr(expr)) =>
+                      o
+                    case o: OptionData.IndexBased if userResponse.contains(o.toString) => o
+                  }
+                case IsRevealingChoice(rc) => rc.options.map(_.choice)
+              }
+              .getOrElse(List.empty[OptionData])
+
+            val includeIfs: List[IncludeIf] = optionData.collect {
+              case OptionData.ValueBased(_, _, Some(includeIf), _, _, _) => includeIf
+              case OptionData.IndexBased(_, _, Some(includeIf), _, _)    => includeIf
+            }
+
+            val isHidden = includeIfs
+              .map(i => booleanExprResolver.resolve(i.booleanExpr))
+              .reduceOption(_ && _)
+              .getOrElse(true)
+            !isHidden
+          case _ => false
+        }
+
+        if (isOptionHidden) {
+          variadicFormDataMap.remove(fcId.modelComponentId)
+        }
+
+        def hiddenIncludeIf = isHiddenByIncludeIf(
+          fcId,
+          evResult,
+          recData,
+          retrievals,
+          evaluationContext,
+          inExprResolver
+        )
+
+        def hiddenComponentIncludeIf = isHiddenByComponentIncludeIf(
+          fcId,
+          evResult,
+          recData,
+          retrievals,
+          evaluationContext,
+          inExprResolver
+        )
+
+        def hiddenRevealingChoice = isHiddenByRevealingChoice(fcId, recData)
+
+        def hiddenRepeatsExpr = isHiddenByRepeatsExpr(fcId, evResult, recData, booleanExprResolver, evaluationContext)
+
+        if (hiddenIncludeIf || hiddenRevealingChoice || hiddenComponentIncludeIf || hiddenRepeatsExpr) {
+          exprMap.addOne((FormCtx(fcId), ExpressionResult.Hidden))
+        } else ()
+
+      case GraphNode.Expr(formCtx @ FormCtx(formComponentId)) =>
+        val expr: Expr = formModel.fcLookup
+          .get(formComponentId)
+          .collect { case HasValueExpr(expr) =>
+            expr
+          }
+          .getOrElse(formCtx)
+        val typeInfo: TypeInfo = formModel.explicitTypedExpr(expr, formComponentId)
+
+        val exprResult: ExpressionResult =
+          evResult
+            .evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
+            .applyTypeInfo(typeInfo)
+        val newExpr = (
+          formCtx,
+          evResult.get(formCtx).fold(exprResult) {
+            case ExpressionResult.Hidden => ExpressionResult.Hidden // If something is Hidden keep it so.
+            case _                       => exprResult
+          }
+        )
+        exprMap.addOne(newExpr)
+
+      case GraphNode.Expr(expr) =>
+        val typeInfo: TypeInfo = formModel.toFirstOperandTypeInfo(expr)
+
+        val exprResult: ExpressionResult =
+          evResult.evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
+
+        exprMap.addOne((expr, exprResult))
+    }
+
+    // We are only interested in `ValidIf` with `In` expression and any other `validIf` is being ignored
+    evalValidIfs(
+      evResult,
+      recData,
+      retrievals,
+      evaluationContext,
+      inExprResolver
+    )
+
+  }
+
+  private def evalBooleanExpr(
     booleanExpr: BooleanExpr,
     evaluationResults: EvaluationResults,
     recData: RecData[SourceOrigin.OutOfDate],
     retrievals: MaterialisedRetrievals,
-    evaluationContext: EvaluationContext
+    evaluationContext: EvaluationContext,
+    inExprResolver: In => Boolean
   )(implicit formModel: FormModel[Interim]): Boolean = {
 
+    //TODO: Instead of using this resolver, evalBooleanExpr should be a tail recursion optimized function.
+    //TODO: This would optimize memory usage for deep expression chains.
     val booleanExprResolver = BooleanExprResolver { booleanExpr =>
-      evalBooleanExprPure(booleanExpr, evaluationResults, recData, retrievals, evaluationContext)
+      evalBooleanExpr(booleanExpr, evaluationResults, recData, retrievals, evaluationContext, inExprResolver)
     }
 
     val rr =
@@ -324,116 +290,10 @@ class Recalculation[F[_]: Monad, E](
       case Contains(field1, field2)            => rr.compare(field1, field2, _ contains _)
       case MatchRegex(expr, regex)             => rr.matchRegex(expr, regex)
       case FormPhase(value)                    => rr.compareFormPhase(value)
-      case In(expr, dataSource)                => false
-      case h @ HasAnswer(_, _) =>
-        BooleanExprEval
-          .evalHasAnswer(
-            h,
-            formModel,
-            evaluationResults,
-            evaluationContext,
-            booleanExprResolver,
-            SourceOrigin.changeSource(recData)
-          )
-      case DuplicateExists(fieldList)      => BooleanExprEval.evalDuplicateExpr(fieldList, recData)
-      case First(FormCtx(formComponentId)) => BooleanExprEval.evalFirstExpr(formComponentId)
-      case IsLogin(value)                  => BooleanExprEval.evalIsLoginExpr(value, retrievals)
-    }
-
-    loop(booleanExpr)
-  }
-
-  private def evalBooleanExpr(
-    booleanExpr: BooleanExpr,
-    evaluationResults: EvaluationResults,
-    recData: RecData[SourceOrigin.OutOfDate],
-    retrievals: MaterialisedRetrievals,
-    booleanExprResolver: BooleanExprResolver,
-    evaluationContext: EvaluationContext,
-    exprMap: mutable.Map[Expr, ExpressionResult],
-    booleanExprCacheMap: mutable.Map[DataSource, mutable.Map[String, Boolean]]
-  )(implicit formModel: FormModel[Interim]): F[Boolean] = {
-
-    val rr =
-      new RecalculationResolver(
-        formModel,
-        evaluationResults,
-        recData,
-        booleanExprResolver,
-        evaluationContext
-      )
-
-    def addToBooleanCache(dataSource: DataSource, value: String, result: Boolean): Unit = {
-      val updatedDataSourceMap =
-        booleanExprCacheMap.get(dataSource).fold(mutable.Map(value -> result)) { m =>
-          m.addOne(value -> result)
-          m
-        }
-      booleanExprCacheMap.addOne(dataSource -> updatedDataSourceMap)
-    }
-
-    def loop(booleanExpr: BooleanExpr): F[Boolean] = booleanExpr match {
-      case Equals(field1, field2)              => rr.compareF(field1, field2, _ identical _)
-      case GreaterThan(field1, field2)         => rr.compareF(field1, field2, _ > _)
-      case DateAfter(field1, field2)           => rr.compareDateF(field1, field2, _ after _)
-      case GreaterThanOrEquals(field1, field2) => rr.compareF(field1, field2, _ >= _)
-      case LessThan(field1, field2)            => rr.compareF(field1, field2, _ < _)
-      case DateBefore(field1, field2)          => rr.compareDateF(field1, field2, _ before _)
-      case LessThanOrEquals(field1, field2)    => rr.compareF(field1, field2, _ <= _)
-      case Not(invertedExpr)                   => loop(invertedExpr).map(!_)
-      case Or(expr1, expr2)                    => for { e1 <- loop(expr1); e2 <- loop(expr2) } yield e1 | e2
-      case And(expr1, expr2)                   => for { e1 <- loop(expr1); e2 <- loop(expr2) } yield e1 & e2
-      case IsTrue                              => true.pure[F]
-      case IsFalse                             => false.pure[F]
-      case Contains(field1, field2)            => rr.compareF(field1, field2, _ contains _)
-      case MatchRegex(expr, regex)             => rr.matchRegexF(expr, regex)
-      case FormPhase(value)                    => rr.compareFormPhaseF(value)
-      case DuplicateExists(fieldList)          => BooleanExprEval.evalDuplicateExpr(fieldList, recData).pure[F]
-      case In(expr, dataSource) =>
-        val typeInfo: TypeInfo = formModel.toFirstOperandTypeInfo(expr)
-        val expressionResult: ExpressionResult =
-          evaluationResults
-            .evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
-            .applyTypeInfo(typeInfo)
-        val hc = evaluationContext.headerCarrier
-
-        expressionResult.convertNumberToString.withStringResult(false.pure[F]) { value =>
-          exprMap.addOne((expr, expressionResult))
-          def makeCall(): F[Boolean] = dataSource match {
-            case DataSource.Mongo(collectionName) => dbLookupCheckStatus(value, collectionName, hc)
-            case DataSource.Enrolment(serviceName, identifierName) =>
-              retrievals.enrolmentExists(serviceName, identifierName, value).pure[F]
-            case dd @ DataSource.DelegatedEnrolment(_, _) =>
-              retrievals.maybeGovermentGatewayId.fold(false.pure[F]) { governmentGatewayId =>
-                delegatedEnrolmentCheckStatus(governmentGatewayId, dd, IdentifierValue(value), hc)
-              }
-            case DataSource.SeissEligible =>
-              seissEligibilityChecker(UtrEligibilityRequest(value), hc)
-          }
-
-          def booleanValue = for {
-            dataSourceValue <- booleanExprCacheMap.get(dataSource)
-            booleanValue    <- dataSourceValue.get(value)
-          } yield booleanValue
-
-          booleanValue.fold(makeCall().map { res =>
-            addToBooleanCache(dataSource, value, res)
-            res
-          })(_.pure[F])
-        }
-      case h @ HasAnswer(_, _) =>
-        BooleanExprEval
-          .evalHasAnswer(
-            h,
-            formModel,
-            evaluationResults,
-            evaluationContext,
-            booleanExprResolver,
-            SourceOrigin.changeSource(recData)
-          )
-          .pure[F]
-      case First(FormCtx(formComponentId)) => BooleanExprEval.evalFirstExpr(formComponentId).pure[F]
-      case IsLogin(value)                  => BooleanExprEval.evalIsLoginExpr(value, retrievals).pure[F]
+      case DuplicateExists(fieldList)          => BooleanExprEval.evalDuplicateExpr(fieldList, recData)
+      case expr: In                            => inExprResolver(expr)
+      case First(FormCtx(formComponentId))     => BooleanExprEval.evalFirstExpr(formComponentId)
+      case IsLogin(value)                      => BooleanExprEval.evalIsLoginExpr(value, retrievals)
     }
 
     loop(booleanExpr)
@@ -443,54 +303,43 @@ class Recalculation[F[_]: Monad, E](
     evaluationResults: EvaluationResults,
     recData: RecData[SourceOrigin.OutOfDate],
     retrievals: MaterialisedRetrievals,
-    booleanExprResolver: BooleanExprResolver,
     evaluationContext: EvaluationContext,
-    exprMap: mutable.Map[Expr, ExpressionResult],
-    booleanExprCacheMap: mutable.Map[DataSource, mutable.Map[String, Boolean]]
+    inExprResolver: In => Boolean
   )(
     booleanExpr: Option[BooleanExpr]
-  )(implicit formModel: FormModel[Interim]): F[Boolean] =
-    booleanExpr.fold(false.pure[F]) { booleanExpr =>
-      for {
-        b <- evalBooleanExpr(
-               booleanExpr,
-               evaluationResults,
-               recData,
-               retrievals,
-               booleanExprResolver,
-               evaluationContext,
-               exprMap,
-               booleanExprCacheMap
-             )
-      } yield !b
+  )(implicit formModel: FormModel[Interim]): Boolean =
+    booleanExpr.fold(false) { booleanExpr =>
+      !evalBooleanExpr(
+        booleanExpr,
+        evaluationResults,
+        recData,
+        retrievals,
+        evaluationContext,
+        inExprResolver
+      )
     }
 
   private def evalValidIfs(
     evaluationResults: EvaluationResults,
     recData: RecData[SourceOrigin.OutOfDate],
     retrievals: MaterialisedRetrievals,
-    booleanExprResolver: BooleanExprResolver,
     evaluationContext: EvaluationContext,
-    exprMap: mutable.Map[Expr, ExpressionResult],
-    booleanExprCacheMap: mutable.Map[DataSource, mutable.Map[String, Boolean]]
-  )(implicit formModel: FormModel[Interim]): F[Unit] = {
+    inExprResolver: In => Boolean
+  )(implicit formModel: FormModel[Interim]): Unit = {
     val validIfs: List[ValidIf] = formModel.allValidIfs.flatMap(_._1)
 
     validIfs
-      .traverse(validIf =>
+      .foreach(validIf =>
         evalBooleanExpr(
           evaluationResults,
           recData,
           retrievals,
-          booleanExprResolver,
           evaluationContext,
-          exprMap,
-          booleanExprCacheMap
+          inExprResolver
         ) {
           Some(validIf.booleanExpr)
         }
       )
-      .void
   }
 
   private def isHiddenByIncludeIf(
@@ -498,20 +347,16 @@ class Recalculation[F[_]: Monad, E](
     evaluationResults: EvaluationResults,
     recData: RecData[SourceOrigin.OutOfDate],
     retrievals: MaterialisedRetrievals,
-    booleanExprResolver: BooleanExprResolver,
     evaluationContext: EvaluationContext,
-    exprMap: mutable.Map[Expr, ExpressionResult],
-    booleanExprCacheMap: mutable.Map[DataSource, mutable.Map[String, Boolean]]
-  )(implicit formModel: FormModel[Interim]): F[Boolean] = {
+    inExprResolver: In => Boolean
+  )(implicit formModel: FormModel[Interim]): Boolean = {
     val pageLookup: Map[FormComponentId, PageModel[Interim]] = formModel.pageLookup
     evalBooleanExpr(
       evaluationResults,
       recData,
       retrievals,
-      booleanExprResolver,
       evaluationContext,
-      exprMap,
-      booleanExprCacheMap
+      inExprResolver
     ) {
       pageLookup
         .get(fcId)
@@ -525,19 +370,15 @@ class Recalculation[F[_]: Monad, E](
     evaluationResults: EvaluationResults,
     recData: RecData[SourceOrigin.OutOfDate],
     retrievals: MaterialisedRetrievals,
-    booleanExprResolver: BooleanExprResolver,
     evaluationContext: EvaluationContext,
-    exprMap: mutable.Map[Expr, ExpressionResult],
-    booleanExprCacheMap: mutable.Map[DataSource, mutable.Map[String, Boolean]]
-  )(implicit formModel: FormModel[Interim]): F[Boolean] =
+    inExprResolver: In => Boolean
+  )(implicit formModel: FormModel[Interim]): Boolean =
     evalBooleanExpr(
       evaluationResults,
       recData,
       retrievals,
-      booleanExprResolver,
       evaluationContext,
-      exprMap,
-      booleanExprCacheMap
+      inExprResolver
     ) {
       formModel.fcLookup
         .get(fcId)
@@ -551,23 +392,22 @@ class Recalculation[F[_]: Monad, E](
     recData: RecData[SourceOrigin.OutOfDate],
     booleanExprResolver: BooleanExprResolver,
     evaluationContext: EvaluationContext
-  )(implicit formModel: FormModel[Interim]): F[Boolean] =
-    formModel.fcIdRepeatsExprLookup.get(fcId).fold(false.pure[F]) { repeatsExpr =>
+  )(implicit formModel: FormModel[Interim]): Boolean =
+    formModel.fcIdRepeatsExprLookup.get(fcId).fold(false) { repeatsExpr =>
       val typeInfo: TypeInfo = formModel.toFirstOperandTypeInfo(repeatsExpr)
       val exprResult: ExpressionResult =
         evResult.evalExpr(typeInfo, recData, booleanExprResolver, evaluationContext)
       fcId.modelComponentId.maybeIndex
         .fold(false)(fcIndex => exprResult.numberRepresentation.fold(true)(fcIndex > _.intValue))
-        .pure[F]
     }
 
   private def isHiddenByRevealingChoice(
     fcId: FormComponentId,
     recData: RecData[SourceOrigin.OutOfDate]
-  )(implicit formModel: FormModel[Interim]): F[Boolean] = {
+  )(implicit formModel: FormModel[Interim]): Boolean = {
 
     val isHidden = formModel.revealingChoiceInfo.isHiddenByParentId(fcId, recData.variadicFormData)
 
-    isHidden.fold(false.pure[F])(x => x.pure[F])
+    isHidden.getOrElse(false)
   }
 }

--- a/app/uk/gov/hmrc/gform/graph/RecalculationResolver.scala
+++ b/app/uk/gov/hmrc/gform/graph/RecalculationResolver.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.gform.graph
 
-import cats.Applicative
-import cats.syntax.all._
 import uk.gov.hmrc.gform.eval.ExpressionResult.DateResult
 import uk.gov.hmrc.gform.eval._
 import uk.gov.hmrc.gform.models.{ FormModel, Interim }
@@ -26,18 +24,13 @@ import uk.gov.hmrc.gform.sharedmodel.formtemplate._
 
 import scala.util.matching.Regex
 
-class RecalculationResolver[F[_]: Applicative](
+class RecalculationResolver(
   formModel: FormModel[Interim],
   evaluationResults: EvaluationResults,
   recData: RecData[SourceOrigin.OutOfDate],
   booleanExprResolver: BooleanExprResolver,
   evaluationContext: EvaluationContext
 ) {
-  def compareF(
-    expr1: Expr,
-    expr2: Expr,
-    f: (ExpressionResult, ExpressionResult) => Boolean
-  ): F[Boolean] = compare(expr1, expr2, f).pure[F]
 
   def compare(
     expr1: Expr,
@@ -58,12 +51,6 @@ class RecalculationResolver[F[_]: Applicative](
     res
   }
 
-  def compareDateF(
-    dateExprLHS: DateExpr,
-    dateExprRHS: DateExpr,
-    f: (DateResult, DateResult) => Boolean
-  ): F[Boolean] = compareDate(dateExprLHS, dateExprRHS, f).pure[F]
-
   def compareDate(
     dateExprLHS: DateExpr,
     dateExprRHS: DateExpr,
@@ -80,9 +67,6 @@ class RecalculationResolver[F[_]: Applicative](
     res
   }
 
-  def matchRegexF(expr: Expr, regex: Regex): F[Boolean] =
-    matchRegex(expr, regex).pure[F]
-
   def matchRegex(expr: Expr, regex: Regex): Boolean = {
     val typeInfo1 = formModel.toFirstOperandTypeInfo(expr)
     val exprRes1: ExpressionResult =
@@ -93,7 +77,5 @@ class RecalculationResolver[F[_]: Applicative](
     exprRes1.matchRegex(regex)
   }
 
-  def compareFormPhaseF(value: FormPhaseValue): F[Boolean] =
-    compareFormPhase(value).pure[F]
   def compareFormPhase(value: FormPhaseValue): Boolean = evaluationContext.formPhase.fold(false)(_.value == value)
 }

--- a/app/uk/gov/hmrc/gform/graph/RecalculationResult.scala
+++ b/app/uk/gov/hmrc/gform/graph/RecalculationResult.scala
@@ -17,16 +17,16 @@
 package uk.gov.hmrc.gform.graph
 
 import uk.gov.hmrc.gform.eval.{ EvaluationContext, EvaluationResults }
-import uk.gov.hmrc.gform.sharedmodel.BooleanExprCache
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.In
 
 final case class RecalculationResult(
   evaluationResults: EvaluationResults,
   graphData: GraphData,
-  booleanExprCache: BooleanExprCache,
-  evaluationContext: EvaluationContext
+  evaluationContext: EvaluationContext,
+  inExprResolver: In => Boolean
 )
 
 object RecalculationResult {
   def empty(evaluationContext: EvaluationContext) =
-    RecalculationResult(EvaluationResults.empty, GraphData.empty, BooleanExprCache.empty, evaluationContext)
+    RecalculationResult(EvaluationResults.empty, GraphData.empty, evaluationContext, _ => false)
 }

--- a/app/uk/gov/hmrc/gform/graph/RecalculationResult.scala
+++ b/app/uk/gov/hmrc/gform/graph/RecalculationResult.scala
@@ -17,16 +17,16 @@
 package uk.gov.hmrc.gform.graph
 
 import uk.gov.hmrc.gform.eval.{ EvaluationContext, EvaluationResults }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.In
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 
 final case class RecalculationResult(
   evaluationResults: EvaluationResults,
   graphData: GraphData,
   evaluationContext: EvaluationContext,
-  inExprResolver: In => Boolean
+  graphDataCache: GraphDataCache
 )
 
 object RecalculationResult {
   def empty(evaluationContext: EvaluationContext) =
-    RecalculationResult(EvaluationResults.empty, GraphData.empty, evaluationContext, _ => false)
+    RecalculationResult(EvaluationResults.empty, GraphData.empty, evaluationContext, GraphDataCache.empty)
 }

--- a/app/uk/gov/hmrc/gform/models/FormModelBuilder.scala
+++ b/app/uk/gov/hmrc/gform/models/FormModelBuilder.scala
@@ -142,7 +142,7 @@ object FormModelBuilder {
       case IsTrue                              => true
       case IsFalse                             => false
       case Contains(field1, field2)            => compare(field1, field2, _ contains _)
-      case in @ In(_, _)                       => BooleanExprEval.evalInExpr(in, formModel, recalculationResult, booleanExprResolver, recData)
+      case in @ In(_, _)                       => BooleanExprEval.evalInExpr(in, recalculationResult)
       case h @ HasAnswer(_, _) =>
         BooleanExprEval.evalHasAnswer(
           h,
@@ -258,7 +258,6 @@ class FormModelBuilder(
         formModel,
         formTemplate,
         retrievals,
-        thirdPartyData,
         evaluationContext,
         messages,
         graphDataCache

--- a/app/uk/gov/hmrc/gform/models/ProcessData.scala
+++ b/app/uk/gov/hmrc/gform/models/ProcessData.scala
@@ -22,19 +22,17 @@ import cats.{ Monad, MonadError }
 import com.softwaremill.quicklens._
 import play.api.i18n.Messages
 import uk.gov.hmrc.gform.controllers.AuthCacheWithForm
+import uk.gov.hmrc.gform.models.gform.ObligationsAction
 import uk.gov.hmrc.gform.models.optics.DataOrigin
-import uk.gov.hmrc.gform.sharedmodel.BooleanExprCache
+import uk.gov.hmrc.gform.sharedmodel._
 import uk.gov.hmrc.gform.sharedmodel.form.{ FormModelOptics, VisitIndex }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Confirmation, FormComponentId, IsHmrcTaxPeriod }
-import uk.gov.hmrc.gform.sharedmodel._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.gform.models.gform.ObligationsAction
 
 case class ProcessData(
   formModelOptics: FormModelOptics[DataOrigin.Browser],
   visitsIndex: VisitIndex,
   obligations: Obligations,
-  booleanExprCache: BooleanExprCache,
   confirmations: Option[Map[FormComponentId, List[String]]]
 ) {
   val formModel: FormModel[DataExpanded] = formModelOptics.formModelRenderPageOptics.formModel
@@ -102,7 +100,6 @@ class ProcessDataService[F[_]: Monad](
           dataUpd,
           cache.form.visitsIndex,
           obligations,
-          browserFormModelOptics.formModelVisibilityOptics.booleanExprCache,
           cache.form.thirdPartyData.confirmations.map(_.map { case (k, v) => k -> v })
         )
       }

--- a/app/uk/gov/hmrc/gform/models/ProcessData.scala
+++ b/app/uk/gov/hmrc/gform/models/ProcessData.scala
@@ -33,6 +33,7 @@ case class ProcessData(
   formModelOptics: FormModelOptics[DataOrigin.Browser],
   visitsIndex: VisitIndex,
   obligations: Obligations,
+  booleanExprCache: BooleanExprCache,
   confirmations: Option[Map[FormComponentId, List[String]]]
 ) {
   val formModel: FormModel[DataExpanded] = formModelOptics.formModelRenderPageOptics.formModel
@@ -100,6 +101,7 @@ class ProcessDataService[F[_]: Monad](
           dataUpd,
           cache.form.visitsIndex,
           obligations,
+          browserFormModelOptics.formModelVisibilityOptics.recalculationResult.graphDataCache.booleanExprCache,
           cache.form.thirdPartyData.confirmations.map(_.map { case (k, v) => k -> v })
         )
       }

--- a/app/uk/gov/hmrc/gform/models/optics/FormModelVisibilityOptics.scala
+++ b/app/uk/gov/hmrc/gform/models/optics/FormModelVisibilityOptics.scala
@@ -16,14 +16,13 @@
 
 package uk.gov.hmrc.gform.models.optics
 
+import com.softwaremill.quicklens._
 import uk.gov.hmrc.gform.eval.{ BooleanExprResolver, EvaluationResults, ExpressionResultWithTypeInfo, TypeInfo }
 import uk.gov.hmrc.gform.graph.{ GraphData, RecData, RecalculationResult }
-import uk.gov.hmrc.gform.models.{ FormModel, FormModelBuilder, Visibility }
 import uk.gov.hmrc.gform.models.ids.ModelComponentId
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Coordinates, Expr, FormPhase, IncludeIf, RemoveItemIf, SectionNumber }
-import uk.gov.hmrc.gform.sharedmodel.{ BooleanExprCache, DataRetrieveId, DataRetrieveResult, SourceOrigin, VariadicValue }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormComponent, FormComponentId }
-import com.softwaremill.quicklens._
+import uk.gov.hmrc.gform.models.{ FormModel, FormModelBuilder, Visibility }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.sharedmodel.{ DataRetrieveId, DataRetrieveResult, SourceOrigin, VariadicValue }
 
 case class FormModelVisibilityOptics[D <: DataOrigin](
   formModel: FormModel[Visibility],
@@ -33,7 +32,6 @@ case class FormModelVisibilityOptics[D <: DataOrigin](
 
   val evaluationResults: EvaluationResults = recalculationResult.evaluationResults
   val graphData: GraphData = recalculationResult.graphData
-  val booleanExprCache: BooleanExprCache = recalculationResult.booleanExprCache
 
   def allFormComponents: List[FormComponent] = formModel.allFormComponents
 

--- a/app/uk/gov/hmrc/gform/sharedmodel/form/ThirdPartyData.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/form/ThirdPartyData.scala
@@ -20,18 +20,18 @@ import cats.data.NonEmptyList
 import cats.implicits._
 import play.api.libs.json.{ Format, Json, OFormat }
 import uk.gov.hmrc.gform.addresslookup.{ AddressLookupResult, PostcodeLookupRetrieve }
+import uk.gov.hmrc.gform.auth.models.ItmpRetrievals
 import uk.gov.hmrc.gform.models.email.{ EmailFieldId, emailFieldId }
 import uk.gov.hmrc.gform.models.ids.ModelComponentId
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Address, FormComponentId, JsonUtils }
 import uk.gov.hmrc.gform.sharedmodel.{ BooleanExprCache, DataRetrieveId, DataRetrieveResult, NotChecked, Obligations }
-import uk.gov.hmrc.gform.auth.models.ItmpRetrievals
 
 case class ThirdPartyData(
   obligations: Obligations,
   emailVerification: Map[EmailFieldId, EmailAndCode],
   queryParams: QueryParams,
   reviewData: Option[Map[String, String]] = None,
-  booleanExprCache: BooleanExprCache,
+  booleanExprCache: BooleanExprCache, //No longer used, need to remove from backend for full removal
   dataRetrieve: Option[Map[DataRetrieveId, DataRetrieveResult]],
   postcodeLookup: Option[Map[FormComponentId, AddressLookupResult]],
   selectedAddresses: Option[Map[FormComponentId, String]],

--- a/app/uk/gov/hmrc/gform/sharedmodel/graph/GraphDataCacheService.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/graph/GraphDataCacheService.scala
@@ -126,9 +126,6 @@ class GraphDataCacheService(
         booleanExprCache
       }
 
-      println(booleanExprCache)
-      println(finalBooleanCache)
-
       GraphDataCache(graph, inExprResolver, finalBooleanCache)
     }
   }

--- a/app/uk/gov/hmrc/gform/sharedmodel/graph/GraphDataCacheService.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/graph/GraphDataCacheService.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.sharedmodel.graph
+
+import cats.syntax.all._
+import scalax.collection.edges.DiEdge
+import scalax.collection.immutable.Graph
+import uk.gov.hmrc.gform.auth.UtrEligibilityRequest
+import uk.gov.hmrc.gform.auth.models.{ IdentifierValue, MaterialisedRetrievals }
+import uk.gov.hmrc.gform.eval.{ AllFormTemplateExpressions, DbLookupChecker, DelegatedEnrolmentChecker, SeissEligibilityChecker }
+import uk.gov.hmrc.gform.models.{ FormModel, FormModelBuilder, Interim, SectionSelector, SectionSelectorType }
+import uk.gov.hmrc.gform.sharedmodel.{ SourceOrigin, VariadicFormData }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ DataSource, FormTemplate, In }
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+case class GraphDataCache(graph: Graph[GraphNode, DiEdge[GraphNode]], inExprResolver: In => Boolean)
+
+class GraphDataCacheService(
+  seissEligibilityChecker: SeissEligibilityChecker,
+  delegatedEnrolmentCheckStatus: DelegatedEnrolmentChecker,
+  dbLookupCheckStatus: DbLookupChecker
+) {
+  def get[U <: SectionSelectorType: SectionSelector](
+    retrievals: MaterialisedRetrievals,
+    variadicFormData: VariadicFormData[SourceOrigin.OutOfDate],
+    formTemplate: FormTemplate,
+    fmb: FormModelBuilder
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[GraphDataCache] = {
+
+    val formModelInterim: FormModel[Interim] = fmb.expand(variadicFormData)
+    val (graph, inExprs) = DependencyGraph.toGraph(formModelInterim, AllFormTemplateExpressions(formTemplate))
+
+    val inExprResolverFtr = {
+      val setOfFutures = inExprs.map { case in @ In(expr, dataSource) =>
+        println(expr)
+        val value =
+          ???
+
+        def makeCall(): Future[Boolean] = dataSource match {
+          case DataSource.Mongo(collectionName) => dbLookupCheckStatus(value, collectionName, hc)
+          case DataSource.Enrolment(serviceName, identifierName) =>
+            retrievals.enrolmentExists(serviceName, identifierName, value).pure[Future]
+          case dd @ DataSource.DelegatedEnrolment(_, _) =>
+            retrievals.maybeGovermentGatewayId.fold(false.pure[Future]) { governmentGatewayId =>
+              delegatedEnrolmentCheckStatus(governmentGatewayId, dd, IdentifierValue(value), hc)
+            }
+          case DataSource.SeissEligible =>
+            seissEligibilityChecker(UtrEligibilityRequest(value), hc)
+        }
+
+        makeCall().map(in -> _)
+      }
+
+      Future
+        .sequence(setOfFutures)
+        .map(_.toMap)
+        .map { map => (in: In) =>
+          map.getOrElse(in, throw new RuntimeException("In expression cannot be evaluated, request is missing"))
+        }
+    }
+
+    inExprResolverFtr.map {
+      GraphDataCache(graph, _)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/gform/tasklist/TaskListModule.scala
+++ b/app/uk/gov/hmrc/gform/tasklist/TaskListModule.scala
@@ -37,7 +37,7 @@ class TaskListModule(
   }
 
   val processDataService: ProcessDataService[Future] =
-    new ProcessDataService[Future](graphModule.recalculation, taxPeriodStateChecker)
+    new ProcessDataService[Future](taxPeriodStateChecker)
 
   val taskListRenderingService = new TaskListRenderingService(
     configModule.frontendAppConfig,

--- a/app/uk/gov/hmrc/gform/tasklist/TaskListRenderingService.scala
+++ b/app/uk/gov/hmrc/gform/tasklist/TaskListRenderingService.scala
@@ -85,7 +85,6 @@ class TaskListRenderingService(
                        .getProcessData[SectionSelectorType.Normal](
                          newDataRaw,
                          cacheUpd,
-                         formModelOptics,
                          gformConnector.getAllTaxPeriods,
                          NoSpecificAction
                        )

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val microservice = (project in file("."))
       "views.html.helper.CSPNonce"
     ),
     scalacOptions ++= Seq(
-      "-Xfatal-warnings",
+      //"-Xfatal-warnings",
       "-Xlint:-missing-interpolator,_",
       "-Xlint:-byname-implicit",
       "-Ywarn-numeric-widen",

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val microservice = (project in file("."))
       "views.html.helper.CSPNonce"
     ),
     scalacOptions ++= Seq(
-      //"-Xfatal-warnings",
+      "-Xfatal-warnings",
       "-Xlint:-missing-interpolator,_",
       "-Xlint:-byname-implicit",
       "-Ywarn-numeric-widen",

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -28,31 +28,31 @@
         </encoder>
     </appender>
 
-    <logger name="com.google.inject" level="ERROR"/>
+    <logger name="com.google.inject" level="INFO"/>
 
-    <logger name="play.core.netty.utils.ServerCookieDecoder" level="ERROR"/>
+    <logger name="play.core.netty.utils.ServerCookieDecoder" level="INFO"/>
 
-    <logger name="uk.gov" level="ERROR"/>
+    <logger name="uk.gov" level="INFO"/>
 
-    <logger name="application" level="ERROR"/>
+    <logger name="application" level="DEBUG"/>
 
-    <logger name="permissions" level="ERROR"  additivity="false">
+    <logger name="permissions" level="INFO"  additivity="false">
         <appender-ref ref="PERMISSIONS_LOG_FILE" />
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <logger name="javax.management.mbeanserver" level="ERROR"/>
+    <logger name="javax.management.mbeanserver" level="INFO"/>
 
     <logger name="org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>
 
-    <logger name="org.mongodb.driver" level="ERROR"/>
-    <logger name="org.apache.pekko" level="ERROR"/>
+    <logger name="org.mongodb.driver" level="INFO"/>
+    <logger name="org.apache.pekko" level="INFO"/>
 
-    <logger name="connector" level="ERROR">
+    <logger name="connector" level="INFO">
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -28,31 +28,31 @@
         </encoder>
     </appender>
 
-    <logger name="com.google.inject" level="INFO"/>
+    <logger name="com.google.inject" level="ERROR"/>
 
-    <logger name="play.core.netty.utils.ServerCookieDecoder" level="INFO"/>
+    <logger name="play.core.netty.utils.ServerCookieDecoder" level="ERROR"/>
 
-    <logger name="uk.gov" level="INFO"/>
+    <logger name="uk.gov" level="ERROR"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="application" level="ERROR"/>
 
-    <logger name="permissions" level="INFO"  additivity="false">
+    <logger name="permissions" level="ERROR"  additivity="false">
         <appender-ref ref="PERMISSIONS_LOG_FILE" />
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <logger name="javax.management.mbeanserver" level="INFO"/>
+    <logger name="javax.management.mbeanserver" level="ERROR"/>
 
     <logger name="org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>
 
-    <logger name="org.mongodb.driver" level="INFO"/>
-    <logger name="org.apache.pekko" level="INFO"/>
+    <logger name="org.mongodb.driver" level="ERROR"/>
+    <logger name="org.apache.pekko" level="ERROR"/>
 
-    <logger name="connector" level="INFO">
+    <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/test/uk/gov/hmrc/gform/GraphSpec.scala
+++ b/test/uk/gov/hmrc/gform/GraphSpec.scala
@@ -17,25 +17,25 @@
 package uk.gov.hmrc.gform
 
 import cats.Monad
-import cats.syntax.applicative._
-
 import uk.gov.hmrc.gform.auth.models.{ GovernmentGatewayId, IdentifierValue }
 import uk.gov.hmrc.gform.eval.BooleanExprEval
 import uk.gov.hmrc.gform.sharedmodel.dblookup.CollectionName
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.DataSource.DelegatedEnrolment
 import uk.gov.hmrc.http.HeaderCarrier
 
+import scala.concurrent.Future
+
 trait GraphSpec {
 
-  def dbLookupStatusTrue[F[_]: Monad](id: String, collectionName: CollectionName, hc: HeaderCarrier): F[Boolean] =
-    true.pure[F]
+  def dbLookupStatusTrue(id: String, collectionName: CollectionName, hc: HeaderCarrier): Future[Boolean] =
+    Future.successful(true)
 
-  def delegatedEnrolmentCheckStatusTrue[F[_]: Monad](
+  def delegatedEnrolmentCheckStatusTrue(
     governmentGatewayId: GovernmentGatewayId,
     delegatedEnrolment: DelegatedEnrolment,
     identifierValue: IdentifierValue,
     hc: HeaderCarrier
-  ): F[Boolean] = true.pure[F]
+  ): Future[Boolean] = Future.successful(true)
 
   def booleanExprEval[F[_]: Monad]: BooleanExprEval[F] = new BooleanExprEval[F]()
 

--- a/test/uk/gov/hmrc/gform/gform/LookupControllerSpec.scala
+++ b/test/uk/gov/hmrc/gform/gform/LookupControllerSpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.gform.gform
 
 import org.apache.pekko.actor.ActorSystem
-import cats.Id
 import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -26,7 +25,6 @@ import play.api.i18n.{ I18nSupport, Messages, MessagesApi }
 import play.api.libs.json.{ Json, Reads }
 import play.api.mvc.{ AnyContent, MessagesControllerComponents, Request, Result }
 import play.api.test.{ FakeRequest, Helpers }
-import uk.gov.hmrc.gform.{ LookupLoader, PlayStubSupport }
 import uk.gov.hmrc.gform.auth.models.OperationWithForm
 import uk.gov.hmrc.gform.controllers.{ AuthCacheWithForm, AuthenticatedRequestActionsAlgebra }
 import uk.gov.hmrc.gform.eval.smartstring.SmartStringEvaluator
@@ -36,10 +34,10 @@ import uk.gov.hmrc.gform.models.ids.{ BaseComponentId, IndexedComponentId, Model
 import uk.gov.hmrc.gform.models.optics.DataOrigin
 import uk.gov.hmrc.gform.models.{ FormModelSupport, LookupQuery, SectionSelectorType, VariadicFormDataSupport }
 import uk.gov.hmrc.gform.sharedmodel.form.FormModelOptics
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ CsvColumnName, FormComponentId, FormCtx, FormTemplateId, Lookup, Register, Section, SelectionCriteria, Text, Value }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.SelectionCriteriaValue.{ SelectionCriteriaExpr, SelectionCriteriaReference, SelectionCriteriaSimpleValue }
-import uk.gov.hmrc.gform.sharedmodel.{ AccessCode, LangADT, SourceOrigin, VariadicFormData, VariadicValue }
-import uk.gov.hmrc.gform.typeclasses.identityThrowableMonadError
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ CsvColumnName, FormComponentId, FormCtx, FormTemplateId, Lookup, Register, Section, SelectionCriteria, Text, Value }
+import uk.gov.hmrc.gform.sharedmodel._
+import uk.gov.hmrc.gform.{ LookupLoader, PlayStubSupport }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -342,10 +340,9 @@ class LookupControllerSpec
     lazy val variadicFormData: VariadicFormData[SourceOrigin.OutOfDate] = VariadicFormData.empty[SourceOrigin.OutOfDate]
     lazy val formModelOptics: FormModelOptics[DataOrigin.Mongo] =
       FormModelOptics
-        .mkFormModelOptics[DataOrigin.Mongo, Id, SectionSelectorType.Normal](
+        .mkFormModelOptics[DataOrigin.Mongo, SectionSelectorType.Normal](
           variadicFormData,
-          authCacheWithForm,
-          recalculation
+          authCacheWithForm
         )
 
     val messagesControllerComponents: MessagesControllerComponents = stubMessagesControllerComponents()

--- a/test/uk/gov/hmrc/gform/gform/StructuredFormDataBuilderSpec.scala
+++ b/test/uk/gov/hmrc/gform/gform/StructuredFormDataBuilderSpec.scala
@@ -16,30 +16,27 @@
 
 package uk.gov.hmrc.gform.gform
 
-import cats.Id
 import cats.data.NonEmptyList
 import cats.instances.either._
 import cats.syntax.either._
+import org.scalactic.source.Position
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import org.scalactic.source.Position
 import play.api.i18n.Messages
 import play.api.test.Helpers
 import uk.gov.hmrc.gform.Helpers.toSmartString
 import uk.gov.hmrc.gform.addresslookup.{ AddressLookupResult, PostcodeLookupRetrieve }
 import uk.gov.hmrc.gform.graph.FormTemplateBuilder._
 import uk.gov.hmrc.gform.lookup._
-import uk.gov.hmrc.gform.models.{ FormModelSupport, SectionSelectorType, VariadicFormDataSupport }
 import uk.gov.hmrc.gform.models.optics.{ DataOrigin, FormModelVisibilityOptics }
-import uk.gov.hmrc.gform.sharedmodel.{ ExampleData, VariadicFormData }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ Destination, DestinationId, Destinations }
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.Destinations.DestinationList
-import uk.gov.hmrc.gform.sharedmodel.{ LangADT, LocalisedString, SourceOrigin }
+import uk.gov.hmrc.gform.models.{ FormModelSupport, SectionSelectorType, VariadicFormDataSupport }
 import uk.gov.hmrc.gform.sharedmodel.form._
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.Destinations.DestinationList
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.destinations.{ Destination, DestinationId, Destinations }
 import uk.gov.hmrc.gform.sharedmodel.structuredform._
-import uk.gov.hmrc.gform.typeclasses.identityThrowableMonadError
+import uk.gov.hmrc.gform.sharedmodel._
 
 class StructuredFormDataBuilderSpec
     extends AnyFlatSpecLike with Matchers with FormModelSupport with VariadicFormDataSupport {
@@ -1353,10 +1350,9 @@ class StructuredFormDataBuilderSpec
   ) = {
 
     val formModelOptics: FormModelOptics[DataOrigin.Mongo] =
-      FormModelOptics.mkFormModelOptics[DataOrigin.Mongo, Id, SectionSelectorType.WithDeclaration](
+      FormModelOptics.mkFormModelOptics[DataOrigin.Mongo, SectionSelectorType.WithDeclaration](
         data,
-        mkAuthCacheWithForm(mkFormTemplate(sections, declarationSection)),
-        recalculation
+        mkAuthCacheWithForm(mkFormTemplate(sections, declarationSection))
       )
 
     formModelOptics.formModelVisibilityOptics

--- a/test/uk/gov/hmrc/gform/graph/DependencyGraphSpec.scala
+++ b/test/uk/gov/hmrc/gform/graph/DependencyGraphSpec.scala
@@ -791,7 +791,7 @@ class DependencyGraphSpec extends AnyFlatSpecLike with Matchers with FormModelSu
     val formTemplateExprs: Set[ExprMetadata] = AllFormTemplateExpressions(formTemplate)
 
     DependencyGraph.constructDependencyGraph(
-      DependencyGraph.toGraph(fm.asInstanceOf[FormModel[Interim]], formTemplateExprs)
+      DependencyGraph.toGraph(fm.asInstanceOf[FormModel[Interim]], formTemplateExprs)._1
     ) match {
 
       case Left(node) => throw new CycleDetectedException(node.outer)

--- a/test/uk/gov/hmrc/gform/models/FastForwardSpec.scala
+++ b/test/uk/gov/hmrc/gform/models/FastForwardSpec.scala
@@ -16,17 +16,18 @@
 
 package uk.gov.hmrc.gform.models
 
-import org.scalatest.prop.TableDrivenPropertyChecks.{ Table, forAll }
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks.{ Table, forAll }
 import play.api.i18n.Messages
 import play.api.test.Helpers
 import uk.gov.hmrc.gform.graph.FormTemplateBuilder.{ mkAddToListSection, mkFormComponent, page }
 import uk.gov.hmrc.gform.models.FastForward.StopAt
 import uk.gov.hmrc.gform.models.optics.DataOrigin
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.SectionNumber.Classic.AddToListPage.TerminalPageKind
-import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SourceOrigin }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Constant, Equals, FormComponentId, FormCtx, IncludeIf, SectionNumber, TemplateSectionIndex, Value }
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
+import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SourceOrigin }
 
 import java.time.Instant
 
@@ -87,7 +88,12 @@ class FastForwardSpec extends AnyFreeSpecLike with FormModelSupport with Variadi
         description in {
           val fmb = mkFormModelFromSections(sections)
           val variadicData = variadicFormData[SourceOrigin.OutOfDate](data: _*)
-          val fmvo = fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](variadicData, None, Instant.now)
+          val fmvo = fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](
+            variadicData,
+            None,
+            Instant.now,
+            GraphDataCache.empty
+          )
           StopAt(stopAt).next(fmvo.formModel, stopAt) shouldBe StopAt(expectedStopAt)
         }
       }

--- a/test/uk/gov/hmrc/gform/models/FormModelBuilderSpec.scala
+++ b/test/uk/gov/hmrc/gform/models/FormModelBuilderSpec.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.gform.models.optics.{ DataOrigin, FormModelVisibilityOptics }
 import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SourceOrigin }
 import uk.gov.hmrc.gform.sharedmodel.form.FormModelOptics
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 
 import java.time.Instant
 
@@ -101,7 +102,7 @@ class FormModelBuilderSpec extends AnyFlatSpecLike with Matchers with FormModelS
 
     forAll(table) { case (data, expectedData, expectedPages) =>
       val visibilityOptics: FormModelVisibilityOptics[DataOrigin.Mongo] =
-        fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now)
+        fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now, GraphDataCache.empty)
 
       val formModelOptics: FormModelOptics[DataOrigin.Mongo] =
         fmb.renderPageModel[DataOrigin.Mongo, SectionSelectorType.Normal](visibilityOptics, None)
@@ -129,7 +130,12 @@ class FormModelBuilderSpec extends AnyFlatSpecLike with Matchers with FormModelS
     val fmb = mkFormModelFromSections(sections)
     val variadicData = variadicFormData[SourceOrigin.OutOfDate]("a" -> "2")
     val visibilityOptics: FormModelVisibilityOptics[DataOrigin.Mongo] =
-      fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](variadicData, None, Instant.now)
+      fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](
+        variadicData,
+        None,
+        Instant.now,
+        GraphDataCache.empty
+      )
     val formModelOptics = fmb.renderPageModel[DataOrigin.Mongo, SectionSelectorType.Normal](visibilityOptics, None)
 
     formModelOptics.formModelRenderPageOptics.formModel.allFormComponentIds shouldBe List(

--- a/test/uk/gov/hmrc/gform/models/helpers/MiniSummaryListHelperSpec.scala
+++ b/test/uk/gov/hmrc/gform/models/helpers/MiniSummaryListHelperSpec.scala
@@ -33,6 +33,7 @@ import uk.gov.hmrc.gform.sharedmodel.{ AccessCode, LangADT }
 import uk.gov.hmrc.gform.sharedmodel.ExampleData.{ buildForm, buildFormComponent, buildFormTemplate, destinationList, nonRepeatingPageSection }
 import uk.gov.hmrc.gform.sharedmodel.form.{ Form, FormData, FormField, FormModelOptics }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormCtx, FormTemplate, FormTemplateContext, ShortText, Text, Value }
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 import uk.gov.hmrc.http.SessionId
 
 class MiniSummaryListHelperSpec extends FunSuite with FormModelSupport {
@@ -57,7 +58,8 @@ class MiniSummaryListHelperSpec extends FunSuite with FormModelSupport {
       FormTemplateContext.basicContext(formTemplate, None),
       Role.Customer,
       maybeAccessCode,
-      new LookupRegistry(Map())
+      new LookupRegistry(Map()),
+      GraphDataCache.empty
     )
 
     lazy val formModelOptics: FormModelOptics[DataOrigin.Mongo] =

--- a/test/uk/gov/hmrc/gform/pdf/PDFRenderServiceSpec.scala
+++ b/test/uk/gov/hmrc/gform/pdf/PDFRenderServiceSpec.scala
@@ -50,6 +50,7 @@ import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import uk.gov.hmrc.gform.lookup.LookupRegistry
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 
 class PDFRenderServiceSpec
     extends AnyFlatSpec with Matchers with ArgumentMatchersSugar with IdiomaticMockito with FormModelSupport
@@ -117,7 +118,8 @@ class PDFRenderServiceSpec
       FormTemplateContext.basicContext(formTemplate, None),
       Role.Customer,
       maybeAccessCode,
-      new LookupRegistry(Map())
+      new LookupRegistry(Map()),
+      GraphDataCache.empty
     )
     lazy val formModelOptics: FormModelOptics[DataOrigin.Mongo] =
       mkFormModelOptics(formTemplate, variadicFormData).asInstanceOf[FormModelOptics[DataOrigin.Mongo]]

--- a/test/uk/gov/hmrc/gform/pdf/model/PDFPageModelBuilderSpec.scala
+++ b/test/uk/gov/hmrc/gform/pdf/model/PDFPageModelBuilderSpec.scala
@@ -38,6 +38,7 @@ import uk.gov.hmrc.gform.validation.{ FieldOk, ValidationResult }
 import uk.gov.hmrc.gform.lookup.LookupRegistry
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.DisplayInSummary
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.MiniSummaryRow.ValueRow
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 
 class PDFPageModelBuilderSpec extends AnyFlatSpec with Matchers with FormModelSupport {
 
@@ -115,7 +116,8 @@ class PDFPageModelBuilderSpec extends AnyFlatSpec with Matchers with FormModelSu
         FormTemplateContext.basicContext(formTemplate, None),
         Role.Customer,
         maybeAccessCode,
-        new LookupRegistry(Map())
+        new LookupRegistry(Map()),
+        GraphDataCache.empty
       )
     lazy val formModelOptics: FormModelOptics[DataOrigin.Mongo] =
       mkFormModelOptics(formTemplate, cache.variadicFormData[SectionSelectorType.WithDeclaration])

--- a/test/uk/gov/hmrc/gform/sharedmodel/graph/GraphDataCacheServiceSuite.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/graph/GraphDataCacheServiceSuite.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.gform.sharedmodel.graph
+
+import munit.FunSuite
+import org.mockito.MockitoSugar.{ times, verify }
+import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import uk.gov.hmrc.gform.auth.UtrEligibilityRequest
+import uk.gov.hmrc.gform.auth.models.{ GovernmentGatewayId, IdentifierValue }
+import uk.gov.hmrc.gform.eval.{ DbLookupChecker, DelegatedEnrolmentChecker, SeissEligibilityChecker }
+import uk.gov.hmrc.gform.graph.FormTemplateBuilder.{ ls, mkFormTemplate, mkSection }
+import uk.gov.hmrc.gform.models.ids.IndexedComponentId.Indexed
+import uk.gov.hmrc.gform.models.ids.{ BaseComponentId, ModelComponentId }
+import uk.gov.hmrc.gform.models.{ FormModelSupport, SectionSelectorType }
+import uk.gov.hmrc.gform.sharedmodel.dblookup.CollectionName
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ DataSource, FormComponent, FormComponentId, FormCtx, In, IncludeIf, ShortText, Text, Value }
+import uk.gov.hmrc.gform.sharedmodel.{ BooleanExprCache, SourceOrigin, VariadicFormData, VariadicValue }
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class GraphDataCacheServiceSuite
+    extends FunSuite with ArgumentMatchersSugar with IdiomaticMockito with FormModelSupport {
+
+  private val mockSeissEligibilityChecker = mock[SeissEligibilityChecker]
+  mockSeissEligibilityChecker(*[UtrEligibilityRequest], *[HeaderCarrier]) shouldReturn Future.successful(true)
+
+  private val mockDelegatedEnrolmentCheckStatus = mock[DelegatedEnrolmentChecker]
+  mockDelegatedEnrolmentCheckStatus(
+    *[GovernmentGatewayId],
+    *[DataSource.DelegatedEnrolment],
+    *[IdentifierValue],
+    *[HeaderCarrier]
+  ) shouldReturn Future.successful(true)
+
+  private val mockDbLookupCheckStatus = mock[DbLookupChecker]
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    reset(mockDbLookupCheckStatus)
+    mockDbLookupCheckStatus(*[String], *[CollectionName], *[HeaderCarrier]) shouldReturn Future.successful(true)
+    super.beforeEach(context)
+  }
+
+  private val service =
+    new GraphDataCacheService(mockSeissEligibilityChecker, mockDelegatedEnrolmentCheckStatus, mockDbLookupCheckStatus)
+
+  private val baseComponentIdValue = "baseComponentId"
+  private val modelComponentId = ModelComponentId.pure(Indexed(BaseComponentId(baseComponentIdValue), 1))
+  private val value = "value"
+  private val data: VariadicFormData[SourceOrigin.OutOfDate] = VariadicFormData(
+    Map.from(
+      Seq(
+        modelComponentId -> VariadicValue.One(value)
+      )
+    )
+  )
+
+  private val dataSource = DataSource.Mongo(CollectionName("test"))
+
+  private val inExpr = In(FormCtx(FormComponentId("1_" + baseComponentIdValue)), dataSource)
+
+  private val formTemplate = mkFormTemplate(
+    mkSection(
+      List(
+        FormComponent(
+          FormComponentId("id"),
+          Text(ShortText.default, Value),
+          ls,
+          false,
+          None,
+          None,
+          Some(
+            IncludeIf(
+              inExpr
+            )
+          ),
+          None,
+          true,
+          false,
+          true,
+          false,
+          false,
+          None,
+          None
+        )
+      )
+    )
+  )
+
+  implicit private val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  test("GraphDataCache updates boolean expr cache if new data is available") {
+    service
+      .get[SectionSelectorType.Normal](
+        retrievals,
+        data,
+        formTemplate,
+        mkFormModelBuilder(formTemplate),
+        BooleanExprCache(Map(dataSource -> Map("other" -> true)))
+      )
+      .map { result =>
+        verify(mockDbLookupCheckStatus, times(1)).apply(
+          any[String],
+          any[CollectionName],
+          any[HeaderCarrier]
+        )
+        assertEquals(
+          result.booleanExprCache,
+          BooleanExprCache(Map(dataSource -> Map("other" -> true, value -> true)))
+        )
+      }
+
+  }
+
+  test("InExprResolver returns the value of resolved Future call") {
+    service
+      .get[SectionSelectorType.Normal](
+        retrievals,
+        data,
+        formTemplate,
+        mkFormModelBuilder(formTemplate),
+        BooleanExprCache.empty
+      )
+      .map { result =>
+        assertEquals(result.inExprResolver(inExpr), true)
+      }
+  }
+
+  test("InExprResolver returns false if the data is yet to be entered") {
+    service
+      .get[SectionSelectorType.Normal](
+        retrievals,
+        data,
+        formTemplate,
+        mkFormModelBuilder(formTemplate),
+        BooleanExprCache.empty
+      )
+      .map { result =>
+        val inExpr = In(FormCtx(FormComponentId("2_" + baseComponentIdValue)), dataSource)
+        assertEquals(result.inExprResolver(inExpr), false)
+      }
+  }
+
+  test("GraphDataCache returns the same boolean expr cache if data was not updated") {
+    service
+      .get[SectionSelectorType.Normal](
+        retrievals,
+        data,
+        formTemplate,
+        mkFormModelBuilder(formTemplate),
+        BooleanExprCache(Map(dataSource -> Map(value -> true)))
+      )
+      .map { result =>
+        verify(mockDbLookupCheckStatus, times(0)).apply(
+          any[String],
+          any[CollectionName],
+          any[HeaderCarrier]
+        )
+        assertEquals(
+          result.booleanExprCache,
+          BooleanExprCache(Map(dataSource -> Map(value -> true)))
+        )
+      }
+  }
+
+  test("InExprResolver throws a runtime exception if called with In expression that can't exist") {
+    service
+      .get[SectionSelectorType.Normal](
+        retrievals,
+        data,
+        formTemplate,
+        mkFormModelBuilder(formTemplate),
+        BooleanExprCache.empty
+      )
+      .map { result =>
+        intercept[RuntimeException](
+          result.inExprResolver(In(FormCtx(FormComponentId("nonExistent")), dataSource))
+        )
+      }
+  }
+}

--- a/test/uk/gov/hmrc/gform/summary/FormComponentSummaryRendererSpec.scala
+++ b/test/uk/gov/hmrc/gform/summary/FormComponentSummaryRendererSpec.scala
@@ -33,6 +33,7 @@ import uk.gov.hmrc.gform.sharedmodel.ExampleData.{ buildForm, buildFormComponent
 import uk.gov.hmrc.gform.sharedmodel.form.{ Form, FormData, FormField, FormModelOptics }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Constant, DisplayInSummary, Equals, FormComponent, FormComponentId, FormCtx, FormTemplate, FormTemplateContext, IncludeIf, InformationMessage, KeyDisplayWidth, MiniSummaryList, MiniSummaryListValue, NoFormat, SectionNumber, SectionOrSummary, SectionTitle4Ga, TemplateSectionIndex, Value }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate.MiniSummaryRow.ValueRow
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 import uk.gov.hmrc.gform.sharedmodel.{ AccessCode, LangADT, LocalisedString, NotChecked, SmartString }
 import uk.gov.hmrc.gform.validation.ValidationResult
 import uk.gov.hmrc.govukfrontend.views.Aliases.{ Empty, Text }
@@ -62,7 +63,8 @@ class FormComponentSummaryRendererSpec extends FunSuite with FormModelSupport {
       FormTemplateContext.basicContext(formTemplate, None),
       Role.Customer,
       maybeAccessCode,
-      new LookupRegistry(Map())
+      new LookupRegistry(Map()),
+      GraphDataCache.empty
     )
 
     lazy val formModelOptics: FormModelOptics[DataOrigin.Mongo] =

--- a/test/uk/gov/hmrc/gform/validation/AddressCheckerSpec.scala
+++ b/test/uk/gov/hmrc/gform/validation/AddressCheckerSpec.scala
@@ -24,8 +24,7 @@ import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import play.api.Configuration
-import play.api.Environment
+import play.api.{ Configuration, Environment }
 import play.api.http.HttpConfiguration
 import play.api.i18n._
 import uk.gov.hmrc.gform.GraphSpec
@@ -33,28 +32,16 @@ import uk.gov.hmrc.gform.Helpers.toSmartString
 import uk.gov.hmrc.gform.auth.models.MaterialisedRetrievals
 import uk.gov.hmrc.gform.controllers.CacheData
 import uk.gov.hmrc.gform.eval.smartstring.SmartStringEvaluator
-import uk.gov.hmrc.gform.objectStore.EnvelopeWithMapping
 import uk.gov.hmrc.gform.graph.FormTemplateBuilder._
 import uk.gov.hmrc.gform.lookup.LookupRegistry
-import uk.gov.hmrc.gform.models.Atom
-import uk.gov.hmrc.gform.models.FormModelSupport
-import uk.gov.hmrc.gform.models.SectionSelectorType
-import uk.gov.hmrc.gform.models.VariadicFormDataSupport
-import uk.gov.hmrc.gform.models.ids.IndexedComponentId
-import uk.gov.hmrc.gform.models.ids.ModelComponentId
-import uk.gov.hmrc.gform.models.optics.DataOrigin
-import uk.gov.hmrc.gform.models.optics.FormModelVisibilityOptics
-import uk.gov.hmrc.gform.sharedmodel.LangADT
-import uk.gov.hmrc.gform.sharedmodel.SmartString
-import uk.gov.hmrc.gform.sharedmodel.SourceOrigin
-import uk.gov.hmrc.gform.sharedmodel.VariadicFormData
-import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
-import uk.gov.hmrc.gform.sharedmodel.form.ThirdPartyData
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.Address
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.FormComponent
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.FormComponentId
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.FormTemplate
-import uk.gov.hmrc.gform.validation.ComponentsValidator
+import uk.gov.hmrc.gform.models.{ Atom, FormModelSupport, SectionSelectorType, VariadicFormDataSupport }
+import uk.gov.hmrc.gform.models.ids.{ IndexedComponentId, ModelComponentId }
+import uk.gov.hmrc.gform.models.optics.{ DataOrigin, FormModelVisibilityOptics }
+import uk.gov.hmrc.gform.objectStore.EnvelopeWithMapping
+import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SmartString, SourceOrigin, VariadicFormData }
+import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, ThirdPartyData }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ Address, FormComponent, FormComponentId, FormTemplate }
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
 import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
 
 import java.time.Instant
@@ -126,7 +113,8 @@ class AddressCheckerSpec
 
     val fmb = mkFormModelFromSections(formTemplate.formKind.allSections.sections.map(_.section))
 
-    val fmvo = fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now)
+    val fmvo =
+      fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now, GraphDataCache.empty)
 
     val cacheData = new CacheData(
       EnvelopeId(""),

--- a/test/uk/gov/hmrc/gform/validation/DateCheckerSpec.scala
+++ b/test/uk/gov/hmrc/gform/validation/DateCheckerSpec.scala
@@ -16,43 +16,31 @@
 
 package uk.gov.hmrc.gform.validation
 
-import cats.data.Validated.Invalid
-import cats.data.Validated.Valid
+import cats.data.Validated.{ Invalid, Valid }
 import cats.implicits._
 import munit.FunSuite
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.Millis
-import org.scalatest.time.Span
-import play.api.Configuration
-import play.api.Environment
+import org.scalatest.time.{ Millis, Span }
 import play.api.http.HttpConfiguration
 import play.api.i18n._
+import play.api.{ Configuration, Environment }
 import uk.gov.hmrc.gform.Helpers.toSmartString
 import uk.gov.hmrc.gform.controllers.CacheData
 import uk.gov.hmrc.gform.eval.smartstring.SmartStringEvaluator
-import uk.gov.hmrc.gform.objectStore.EnvelopeWithMapping
 import uk.gov.hmrc.gform.graph.FormTemplateBuilder._
 import uk.gov.hmrc.gform.lookup.LookupRegistry
-import uk.gov.hmrc.gform.models.Atom
-import uk.gov.hmrc.gform.models.FormModelSupport
-import uk.gov.hmrc.gform.models.SectionSelectorType
-import uk.gov.hmrc.gform.models.VariadicFormDataSupport
-import uk.gov.hmrc.gform.models.ids.BaseComponentId
-import uk.gov.hmrc.gform.models.ids.IndexedComponentId
-import uk.gov.hmrc.gform.models.ids.ModelComponentId
-import uk.gov.hmrc.gform.models.optics.DataOrigin
-import uk.gov.hmrc.gform.models.optics.FormModelVisibilityOptics
-import uk.gov.hmrc.gform.sharedmodel.LangADT
-import uk.gov.hmrc.gform.sharedmodel.SmartString
-import uk.gov.hmrc.gform.sharedmodel.SourceOrigin
-import uk.gov.hmrc.gform.sharedmodel.VariadicFormData
-import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
-import uk.gov.hmrc.gform.sharedmodel.form.ThirdPartyData
+import uk.gov.hmrc.gform.models.ids.{ BaseComponentId, IndexedComponentId, ModelComponentId }
+import uk.gov.hmrc.gform.models.optics.{ DataOrigin, FormModelVisibilityOptics }
+import uk.gov.hmrc.gform.models.{ Atom, FormModelSupport, SectionSelectorType, VariadicFormDataSupport }
+import uk.gov.hmrc.gform.objectStore.EnvelopeWithMapping
+import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, ThirdPartyData }
 import uk.gov.hmrc.gform.sharedmodel.formtemplate._
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
+import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SmartString, SourceOrigin, VariadicFormData }
 import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
 
-import java.time.{ Instant, LocalDate }
 import java.time.format.DateTimeFormatter
+import java.time.{ Instant, LocalDate }
 import scala.collection.mutable.LinkedHashSet
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -116,7 +104,8 @@ class DateCheckerSpec extends FunSuite with FormModelSupport with VariadicFormDa
 
     val fmb = mkFormModelFromSections(formTemplate.formKind.allSections.sections.map(_.section))
 
-    val fmvo = fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now)
+    val fmvo =
+      fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now, GraphDataCache.empty)
 
     val cacheData = new CacheData(
       EnvelopeId(""),

--- a/test/uk/gov/hmrc/gform/validation/OverseasAddressCheckerSpec.scala
+++ b/test/uk/gov/hmrc/gform/validation/OverseasAddressCheckerSpec.scala
@@ -24,36 +24,24 @@ import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import play.api.Configuration
-import play.api.Environment
 import play.api.http.HttpConfiguration
 import play.api.i18n._
+import play.api.{ Configuration, Environment }
 import uk.gov.hmrc.gform.GraphSpec
 import uk.gov.hmrc.gform.Helpers.toSmartString
 import uk.gov.hmrc.gform.auth.models.MaterialisedRetrievals
 import uk.gov.hmrc.gform.controllers.CacheData
 import uk.gov.hmrc.gform.eval.smartstring.SmartStringEvaluator
-import uk.gov.hmrc.gform.objectStore.EnvelopeWithMapping
 import uk.gov.hmrc.gform.graph.FormTemplateBuilder._
 import uk.gov.hmrc.gform.lookup.LookupRegistry
-import uk.gov.hmrc.gform.models.Atom
-import uk.gov.hmrc.gform.models.FormModelSupport
-import uk.gov.hmrc.gform.models.SectionSelectorType
-import uk.gov.hmrc.gform.models.VariadicFormDataSupport
-import uk.gov.hmrc.gform.models.ids.IndexedComponentId
-import uk.gov.hmrc.gform.models.ids.ModelComponentId
-import uk.gov.hmrc.gform.models.optics.DataOrigin
-import uk.gov.hmrc.gform.models.optics.FormModelVisibilityOptics
-import uk.gov.hmrc.gform.sharedmodel.LangADT
-import uk.gov.hmrc.gform.sharedmodel.SmartString
-import uk.gov.hmrc.gform.sharedmodel.SourceOrigin
-import uk.gov.hmrc.gform.sharedmodel.VariadicFormData
-import uk.gov.hmrc.gform.sharedmodel.form.EnvelopeId
-import uk.gov.hmrc.gform.sharedmodel.form.ThirdPartyData
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.FormComponent
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.FormComponentId
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.FormTemplate
-import uk.gov.hmrc.gform.sharedmodel.formtemplate.OverseasAddress
+import uk.gov.hmrc.gform.models.ids.{ IndexedComponentId, ModelComponentId }
+import uk.gov.hmrc.gform.models.optics.{ DataOrigin, FormModelVisibilityOptics }
+import uk.gov.hmrc.gform.models.{ Atom, FormModelSupport, SectionSelectorType, VariadicFormDataSupport }
+import uk.gov.hmrc.gform.objectStore.EnvelopeWithMapping
+import uk.gov.hmrc.gform.sharedmodel.form.{ EnvelopeId, ThirdPartyData }
+import uk.gov.hmrc.gform.sharedmodel.formtemplate.{ FormComponent, FormComponentId, FormTemplate, OverseasAddress }
+import uk.gov.hmrc.gform.sharedmodel.graph.GraphDataCache
+import uk.gov.hmrc.gform.sharedmodel.{ LangADT, SmartString, SourceOrigin, VariadicFormData }
 import uk.gov.hmrc.gform.validation.ValidationUtil.ValidatedType
 
 import java.time.Instant
@@ -132,7 +120,8 @@ class OverseasAddressCheckerSpec
 
     val fmb = mkFormModelFromSections(formTemplate.formKind.allSections.sections.map(_.section))
 
-    val fmvo = fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now)
+    val fmvo =
+      fmb.visibilityModel[DataOrigin.Mongo, SectionSelectorType.Normal](data, None, Instant.now, GraphDataCache.empty)
 
     val cacheData = new CacheData(
       EnvelopeId(""),


### PR DESCRIPTION
Main changes:
```
class Recalculation[F[_]: Monad, E](
  val seissEligibilityChecker: SeissEligibilityChecker[F],
  val delegatedEnrolmentCheckStatus: DelegatedEnrolmentChecker[F],
  val dbLookupCheckStatus: DbLookupChecker[F],
  val error: GraphException => E
)
Changed to:
object Recalculation

Recalculation.recalculateFormDataNew(
    data: VariadicFormData[SourceOrigin.OutOfDate],
    formModel: FormModel[Interim],
    formTemplate: FormTemplate,
    retrievals: MaterialisedRetrievals,
    thirdPartyData: ThirdPartyData,
    evaluationContext: EvaluationContext,
    messages: Messages
  )(implicit me: MonadError[F, E]): F[RecalculationResult]
  
Changed to: 
Recalculation.recalculateFormDataNew(
    data: VariadicFormData[SourceOrigin.OutOfDate],
    formModel: FormModel[Interim],
    formTemplate: FormTemplate,
    retrievals: MaterialisedRetrievals,
    evaluationContext: EvaluationContext,
    messages: Messages,
    graphDataCache: GraphDataCache
  ): RecalculationResult
```

Introduced GraphDataCacheService, used to assemble any data that is required for Recalculation (GraphDataCache), such as (InExprResolver).
GraphDataCache is created right after Authentication in  AuthenticatedRequestActions where InExprResolver is created from form template Graph and existing formData any Future calls made pre-emptively before calculations.

Any other changes were made to comply with the changes to the above interfaces.