### PR TITLE
GFORMS-3534 - Add new properties to confirmation component to define …

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/NewFormController.scala
+++ b/app/uk/gov/hmrc/gform/gform/NewFormController.scala
@@ -880,8 +880,9 @@ class NewFormController(
       cacheWithForm.variadicFormData[SectionSelectorType.Normal],
       cacheWithForm
     )
+    val cacheWithFormUpd = removeConfirmations(cacheWithForm, formModelOptics)
     for {
-      cacheUpdated <- maybeUpdateItmpCache(request, cacheWithForm, formModelOptics)
+      cacheUpdated <- maybeUpdateItmpCache(request, cacheWithFormUpd, formModelOptics)
       r <- cache.formTemplate.formKind.fold { classic =>
              fastForwardService.redirectFastForward(cacheUpdated, accessCode, formModelOptics, None, SuppressErrors.Yes)
            } { taskList =>


### PR DESCRIPTION
…the field IDs and expressions that should reset the confirmation if they change

Reset confirmations on return to the form for agents