### PR TITLE
GFORMS-3682 - Updates for Implementing GOV.UK design refresh of page header and footers in gForms

### DIFF
--- a/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplate.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/formtemplate/FormTemplate.scala
@@ -61,7 +61,8 @@ case class FormTemplate(
   displayAccountHeader: Boolean,
   serviceStartPageUrl: Option[ServiceStartPageUrl],
   downloadPreviousSubmissionPdf: Boolean,
-  overrides: Option[Overrides]
+  overrides: Option[Overrides],
+  serviceNavigationComponent: Boolean
 ) {
 
   val isSpecimen: Boolean = _id.value.startsWith("specimen-")

--- a/app/uk/gov/hmrc/gform/views/custom/CustomHmrcHeader.scala.html
+++ b/app/uk/gov/hmrc/gform/views/custom/CustomHmrcHeader.scala.html
@@ -29,7 +29,7 @@
 * This is a customised version of the HMRC frontend header to allow usage  *
 * of GovukServiceNavigation and a custom user research banner              *
 ***************************************************************************@
-@this(hmrcBanner: HmrcBanner, hmrcUserResearchBanner: CustomUserResearchBanner, govukPhaseBanner: GovukPhaseBanner, tudorCrownConfig: TudorCrownConfig, rebrandConfig: RebrandConfig, govukLogo: GovukLogo, displayServiceNavigation: Boolean)
+@this(hmrcBanner: HmrcBanner, hmrcUserResearchBanner: CustomUserResearchBanner, govukPhaseBanner: GovukPhaseBanner, tudorCrownConfig: TudorCrownConfig, rebrandConfig: RebrandConfig, govukLogo: GovukLogo, displayServiceNavigation: Boolean, taskListServiceUrl: String)
 
 @(params: Header)(implicit messages: Messages)
 @import params._
@@ -121,7 +121,7 @@
     </div>
     </div>
     @if(displayServiceNavigation && rebrandConfig.useRebrand) {
-        @govukServiceNavigation(new ServiceNavigation(serviceName = serviceName))
+        @govukServiceNavigation(new ServiceNavigation(serviceName = serviceName, serviceUrl = if (taskListServiceUrl.isEmpty) None else Some(taskListServiceUrl)))
     }
     @phaseBanner.map { pb =>
         <div class="govuk-width-container">

--- a/app/uk/gov/hmrc/gform/views/custom/CustomHmrcHeader.scala.html
+++ b/app/uk/gov/hmrc/gform/views/custom/CustomHmrcHeader.scala.html
@@ -19,21 +19,26 @@
 @import uk.gov.hmrc.hmrcfrontend.views.Aliases.{Banner, Header, UserResearchBanner}
 
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Cy
-@import uk.gov.hmrc.hmrcfrontend.config.TudorCrownConfig
+@import uk.gov.hmrc.hmrcfrontend.config.{TudorCrownConfig, RebrandConfig}
 @import uk.gov.hmrc.hmrcfrontend.views.Utils.nonEmptyStringOrDefault
+@import uk.gov.hmrc.govukfrontend.views.html.helpers.GovukLogo
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.servicenavigation.ServiceNavigation
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukServiceNavigation
 
 @***************************************************************************
-* The only material difference between this custom header and the header   *
-* from the HMRC frontend library is the custom user research banner        *
+* This is a customised version of the HMRC frontend header to allow usage  *
+* of GovukServiceNavigation and a custom user research banner              *
 ***************************************************************************@
-@this(hmrcBanner: HmrcBanner, hmrcUserResearchBanner: CustomUserResearchBanner, govukPhaseBanner: GovukPhaseBanner, tudorCrownConfig: TudorCrownConfig)
+@this(hmrcBanner: HmrcBanner, hmrcUserResearchBanner: CustomUserResearchBanner, govukPhaseBanner: GovukPhaseBanner, tudorCrownConfig: TudorCrownConfig, rebrandConfig: RebrandConfig, govukLogo: GovukLogo, displayServiceNavigation: Boolean)
 
-@(params: Header)
+@(params: Header)(implicit messages: Messages)
 @import params._
 
 @containerClassList = @{
     Seq("govuk-header__container", nonEmptyStringOrDefault(Option(containerClasses), "govuk-width-container")).mkString(" ")
 }
+
+@govukServiceNavigation = @{new GovukServiceNavigation()}
 
 <header>
     <div class="govuk-header @toClasses("hmrc-header", classes)@if(signOutHref.exists(_.nonEmpty) || languageToggle.exists(_.linkMap.nonEmpty)){ hmrc-header--with-additional-navigation}" data-module="govuk-header"
@@ -41,57 +46,29 @@
     <div class="@toClasses(containerClassList)">
         <div class="govuk-header__logo">
             <a href="@nonEmptyStringOrDefault(Option(homepageUrl), "/")" class="govuk-header__link govuk-header__link--homepage">
-            @**************************************************************************
-            * The SVG needs `focusable="false"` so that Internet Explorer does        *
-            * not treat it as an interactive element - without this it will be        *
-            * 'focusable' when using the keyboard to navigate.                        *
-            *                                                                         *
-            * We use a single compound path for the logo to prevent subpixel rounding *
-            * shifting different elements unevenly relative to one another.           *
-            **************************************************************************@
-            @if(useTudorCrown.getOrElse(tudorCrownConfig.useTudorCrown)) {
-            <svg
-                    focusable="false"
-                    role="img"
-                    class="govuk-header__logotype"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 148 30"
-                    height="30"
-                    width="148"
-                    aria-label="GOV.UK"
-            >
-                <title>GOV.UK</title>
-                <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-            </svg>
-            } else {
-            <svg
-                    focusable="false"
-                    role="img"
-                    class="govuk-header__logotype"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 152 30"
-                    height="30"
-                    width="152"
-                    aria-label="GOV.UK"
-            >
-                <title>GOV.UK</title>
-                <path d="M6.7 12.2c1 .4 2.1-.1 2.5-1s-.1-2.1-1-2.5c-1-.4-2.1.1-2.5 1-.4 1 0 2.1 1 2.5m-4.3 2.5c1 .4 2.1-.1 2.5-1s-.1-2.1-1-2.5c-1-.4-2.1.1-2.5 1-.5 1 0 2.1 1 2.5m-1.3 4.8c1 .4 2.1-.1 2.5-1 .4-1-.1-2.1-1-2.5-1-.4-2.1.1-2.5 1-.4 1 0 2.1 1 2.5m10.4-5.8c1 .4 2.1-.1 2.5-1s-.1-2.1-1-2.5c-1-.4-2.1.1-2.5 1s0 2.1 1 2.5m17.4-1.5c-1 .4-2.1-.1-2.5-1s.1-2.1 1-2.5c1-.4 2.1.1 2.5 1 .5 1 0 2.1-1 2.5m4.3 2.5c-1 .4-2.1-.1-2.5-1s.1-2.1 1-2.5c1-.4 2.1.1 2.5 1 .5 1 0 2.1-1 2.5m1.3 4.8c-1 .4-2.1-.1-2.5-1-.4-1 .1-2.1 1-2.5 1-.4 2.1.1 2.5 1 .4 1 0 2.1-1 2.5m-10.4-5.8c-1 .4-2.1-.1-2.5-1s.1-2.1 1-2.5c1-.4 2.1.1 2.5 1s0 2.1-1 2.5m-5.3-4.9 2.4 1.3V6.5l-2.4.8c-.1-.1-.1-.2-.2-.2s1-3 1-3h-3.4l1 3c-.1.1-.2.1-.2.2-.1.1-2.4-.7-2.4-.7v3.5L17 8.8c-.1.1 0 .2.1.3l-1.4 4.2c-.1.2-.1.4-.1.7 0 1.1.8 2.1 1.9 2.2h.6C19.2 16 20 15.1 20 14c0-.2 0-.4-.1-.7l-1.4-4.2c.2-.1.3-.2.3-.3m-1 20.3c4.6 0 8.9.3 12.8.9 1.1-4.6 2.4-7.2 3.8-9.1l-2.6-.9c.3 1.3.3 1.9 0 2.8-.4-.4-.8-1.2-1.1-2.4l-1.2 4.2c.8-.5 1.4-.9 2-.9-1.2 2.6-2.7 3.2-3.6 3-1.2-.2-1.7-1.3-1.5-2.2.3-1.3 1.6-1.6 2.2-.1 1.2-2.4-.8-3.1-2.1-2.4 1.9-1.9 2.2-3.6.6-5.7-2.2 1.7-2.2 3.3-1.2 5.6-1.3-1.5-3.3-.7-2.5 1.7.9-1.4 2.1-.5 2 .8-.2 1.2-1.7 2.1-3.7 2-2.8-.2-3-2.2-3-3.7.7-.1 1.9.5 3 2l.4-4.4c-1.1 1.2-2.2 1.4-3.3 1.4.4-1.2 2.1-3.1 2.1-3.1h-5.5s1.8 2 2.1 3.1c-1.1 0-2.2-.3-3.3-1.4l.4 4.4c1.1-1.5 2.3-2.1 3-2-.1 1.6-.2 3.5-3 3.7-1.9.2-3.5-.8-3.7-2-.2-1.3 1-2.2 1.9-.8.7-2.4-1.3-3.1-2.6-1.7 1-2.3 1-4-1.2-5.6-1.6 2.1-1.3 3.8.6 5.7-1.3-.7-3.2 0-2.1 2.4.6-1.5 1.9-1.1 2.2.1.2.9-.4 1.9-1.5 2.2-1 .2-2.5-.5-3.7-3 .7 0 1.3.4 2 .9L5 20.4c-.3 1.2-.7 1.9-1.2 2.4-.3-.8-.2-1.5 0-2.8l-2.6.9C2.7 22.8 4 25.4 5.1 30c3.8-.5 8.2-.9 12.7-.9m30.5-11.5c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H59v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zm36.4-4.3c-.4-1.3-1.1-2.4-2-3.4-.9-1-1.9-1.7-3.1-2.3-1.2-.6-2.6-.8-4.2-.8s-2.9.3-4.2.8c-1.1.6-2.2 1.4-3 2.3-.9 1-1.5 2.1-2 3.4-.4 1.3-.7 2.7-.7 4.2s.2 2.9.7 4.2c.4 1.3 1.1 2.4 2 3.4.9 1 1.9 1.7 3.1 2.3 1.2.6 2.6.8 4.2.8 1.5 0 2.9-.3 4.2-.8 1.2-.6 2.3-1.3 3.1-2.3.9-1 1.5-2.1 2-3.4.4-1.3.7-2.7.7-4.2-.1-1.5-.3-2.9-.8-4.2zM81 17.6c0 1-.1 1.9-.4 2.7-.2.8-.6 1.6-1.1 2.2-.5.6-1.1 1.1-1.7 1.4-.7.3-1.5.5-2.4.5-.9 0-1.7-.2-2.4-.5s-1.3-.8-1.7-1.4c-.5-.6-.8-1.3-1.1-2.2-.2-.8-.4-1.7-.4-2.7v-.1c0-1 .1-1.9.4-2.7.2-.8.6-1.6 1.1-2.2.5-.6 1.1-1.1 1.7-1.4.7-.3 1.5-.5 2.4-.5.9 0 1.7.2 2.4.5s1.3.8 1.7 1.4c.5.6.8 1.3 1.1 2.2.2.8.4 1.7.4 2.7v.1zM92.9 28 87 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L152 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
-            </svg>
-            }
-            @productName match {
-                case Some(NonEmptyString(x)) => {
-                    <span class="govuk-header__product-name">
-                        @x
-                    </span>
+                @govukLogo(
+                    useRebrand = rebrandConfig.useRebrand,
+                    useTudorCrown = tudorCrownConfig.useTudorCrown,
+                    useLogotype = true,
+                    svgClass = "govuk-header__logotype",
+                    ariaLabelText = Some("GOV.UK")
+                )
+                @productName match {
+                    case Some(NonEmptyString(x)) => {
+                        <span class="govuk-header__product-name">
+                            @x
+                        </span>
+                    }
+                    case _ => {}
                 }
-                case _ => {}
-            }
             </a>
         </div>
 
         @if(serviceName.exists(_.nonEmpty) || signOutHref.exists(_.nonEmpty) || (navigation.getOrElse(Seq.empty).nonEmpty) || languageToggle.exists(_.linkMap.nonEmpty)) {
         <div class="govuk-header__content">
-            @serviceNameLinkOrSpan(serviceName, serviceUrl)
+            @if(!displayServiceNavigation || !rebrandConfig.useRebrand) {
+                @serviceNameLinkOrSpan(serviceName, serviceUrl)
+            }
             @if(navigation.getOrElse(Seq.empty).nonEmpty) {
             <nav aria-label="@params.navigationLabel.getOrElse(menuButtonText)" class="@toClasses("govuk-header__navigation", navigationClasses)">
             <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" @menuButtonAriaLabel hidden> @menuButtonText </button>
@@ -143,6 +120,9 @@
         } else {}
     </div>
     </div>
+    @if(displayServiceNavigation && rebrandConfig.useRebrand) {
+        @govukServiceNavigation(new ServiceNavigation(serviceName = serviceName))
+    }
     @phaseBanner.map { pb =>
         <div class="govuk-width-container">
             @govukPhaseBanner(pb)

--- a/app/uk/gov/hmrc/gform/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/gform/views/govuk_wrapper.scala.html
@@ -77,6 +77,10 @@
   maybeFormTemplate.exists(_.displayAccountHeader)
 }
 
+@displayServiceNavigation = @{
+  maybeFormTemplate.exists(_.serviceNavigationComponent)
+}
+
 @serviceStartPageUrl = @{
   maybeFormTemplate.flatMap(_.serviceStartPageUrl.map(_.value))
 }
@@ -187,7 +191,7 @@
 @hmrcBanner = @{new components.HmrcBanner(tudorCrownConfig)}
 @hmrcUserResearchBanner = @{new CustomUserResearchBanner}
 @govukPhaseBanner = @{new GovukPhaseBanner(govukTag = new GovukTag())}
-@hmrcHeader = @{new CustomHmrcHeader(hmrcBanner, hmrcUserResearchBanner, govukPhaseBanner, tudorCrownConfig)}
+@hmrcHeader = @{new CustomHmrcHeader(hmrcBanner, hmrcUserResearchBanner, govukPhaseBanner, tudorCrownConfig, rebrandConfig, govukLogo, displayServiceNavigation)}
 @hmrcFooter = @{new components.HmrcFooter(govukFooter)}
 @fixedWidthPageLayout = @{new FixedWidthPageLayout()}
 @govukTemplate = @{new GovukTemplate(govukHeader, govukFooter, govukSkipLink, fixedWidthPageLayout, rebrandConfig)}

--- a/app/uk/gov/hmrc/gform/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/gform/views/govuk_wrapper.scala.html
@@ -191,7 +191,7 @@
 @hmrcBanner = @{new components.HmrcBanner(tudorCrownConfig)}
 @hmrcUserResearchBanner = @{new CustomUserResearchBanner}
 @govukPhaseBanner = @{new GovukPhaseBanner(govukTag = new GovukTag())}
-@hmrcHeader = @{new CustomHmrcHeader(hmrcBanner, hmrcUserResearchBanner, govukPhaseBanner, tudorCrownConfig, rebrandConfig, govukLogo, displayServiceNavigation)}
+@hmrcHeader = @{new CustomHmrcHeader(hmrcBanner, hmrcUserResearchBanner, govukPhaseBanner, tudorCrownConfig, rebrandConfig, govukLogo, displayServiceNavigation, serviceLink)}
 @hmrcFooter = @{new components.HmrcFooter(govukFooter)}
 @fixedWidthPageLayout = @{new FixedWidthPageLayout()}
 @govukTemplate = @{new GovukTemplate(govukHeader, govukFooter, govukSkipLink, fixedWidthPageLayout, rebrandConfig)}

--- a/it/test/uk/gov/hmrc/gform/sample/FormTemplateSample.scala
+++ b/it/test/uk/gov/hmrc/gform/sample/FormTemplateSample.scala
@@ -171,7 +171,8 @@ trait FormTemplateSample {
     displayAccountHeader = false,
     serviceStartPageUrl = None,
     downloadPreviousSubmissionPdf = true,
-    overrides = None
+    overrides = None,
+    serviceNavigationComponent = false
   )
 
   val formTemplateEmailAuthWithOptionalDetails = formTemplateEmailAuth.copy(

--- a/test/uk/gov/hmrc/gform/graph/FormTemplateBuilder.scala
+++ b/test/uk/gov/hmrc/gform/graph/FormTemplateBuilder.scala
@@ -336,7 +336,8 @@ object FormTemplateBuilder {
     false,
     None,
     true,
-    None
+    None,
+    false
   )
 
   def addToListQuestion(addAnotherQuestionName: String): FormComponent =

--- a/test/uk/gov/hmrc/gform/playcomponents/EmailAuthSessionPurgeFilterSpec.scala
+++ b/test/uk/gov/hmrc/gform/playcomponents/EmailAuthSessionPurgeFilterSpec.scala
@@ -216,7 +216,8 @@ class EmailAuthSessionPurgeFilterSpec extends Spec {
     displayAccountHeader = false,
     serviceStartPageUrl = None,
     downloadPreviousSubmissionPdf = true,
-    overrides = None
+    overrides = None,
+    serviceNavigationComponent = false
   )
 
 }

--- a/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/ExampleData.scala
@@ -926,7 +926,8 @@ trait ExampleFormTemplate {
       false,
       None,
       true,
-      None
+      None,
+      false
     )
 }
 

--- a/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/FormTemplateGen.scala
+++ b/test/uk/gov/hmrc/gform/sharedmodel/formtemplate/generators/FormTemplateGen.scala
@@ -159,7 +159,8 @@ trait FormTemplateGen {
       false,
       serviceStartPageUrl,
       true,
-      None
+      None,
+      false
     )
 }
 


### PR DESCRIPTION
Use the updated gov.uk logo and add option to use govuk service navigation component for displaying the form title