### PR TITLE
GFORMS-4210: India FTA – RCM API Integration E2E-Testing

### DIFF
--- a/app/uk/gov/hmrc/gform/gform/PopulateAtlService.scala
+++ b/app/uk/gov/hmrc/gform/gform/PopulateAtlService.scala
@@ -101,8 +101,16 @@ object PopulateAtlService {
         PopulateAtlData(accFields ++ fields, baseIds ++ seq)
     }
 
+    val oldPopulateAtlFieldsToClean = populateAtlData.baseIds
+    val oldData = formModelRenderPageOptics.recData.variadicFormData
+    val oldDataWithoutPopulateAtl = oldPopulateAtlFieldsToClean.foldLeft(oldData) { case (acc, bcId) =>
+      acc.forBaseComponentId(bcId).foldLeft(acc) { case (acc, (mcId, value)) =>
+        acc.-(mcId)
+      }
+    }
+
     val updatedVariadicFormData = populateAtlData.fields
-      .foldLeft(formModelRenderPageOptics.recData.variadicFormData) { case (acc, field) =>
+      .foldLeft(oldDataWithoutPopulateAtl) { case (acc, field) =>
         acc.addMany(field.id -> Seq(field.value))
       }
 
@@ -136,9 +144,12 @@ object PopulateAtlService {
         .headOption
         .head
     }
+    val cleanVisitSection = populateAtlDataWithTemplateIndex.foldLeft(visitsIndex) { case (acc, atlSection) =>
+      acc.removeIterationFull(atlSection)
+    }
 
     val visitedPopulateAtlPagesVisitsIndex =
-      populateAtlDataWithTemplateIndex.foldLeft(visitsIndex) { case (acc, atlSection) =>
+      populateAtlDataWithTemplateIndex.foldLeft(cleanVisitSection) { case (acc, atlSection) =>
         val fm = renderPageOptics.formModel
         fm.addToListSectionNumbers.foldLeft(acc) { case (visitIndexAcc, sectionNumber) =>
           sectionNumber match {

--- a/app/uk/gov/hmrc/gform/gform/handlers/FormValidator.scala
+++ b/app/uk/gov/hmrc/gform/gform/handlers/FormValidator.scala
@@ -211,7 +211,11 @@ class FormValidator(implicit ec: ExecutionContext) {
             case (Some(yesTo), SectionOrSummary.FormSummary, _) =>
               nextFrom
                 .map { nextFrom =>
-                  SectionOrSummary.Section(findLastATLSectionNumber(nextFrom))
+                  if (processData.visitsIndex.contains(nextFrom)) { //For populateAtl pre-filled data
+                    SectionOrSummary.Section(findLastATLSectionNumber(nextFrom))
+                  } else {
+                    SectionOrSummary.Section(nextFrom)
+                  }
                 }
                 .getOrElse(SectionOrSummary.FormSummary)
             case (Some(yesTo), SectionOrSummary.Section(cyaTo), _) if cyaTo > yesTo =>

--- a/app/uk/gov/hmrc/gform/sharedmodel/form/VisitIndex.scala
+++ b/app/uk/gov/hmrc/gform/sharedmodel/form/VisitIndex.scala
@@ -50,6 +50,19 @@ sealed trait VisitIndex extends Product with Serializable {
   def visit(sectionNumber: SectionNumber): VisitIndex = sectionNumber.fold(visitClassic)(visitTaskList)
   def unvisit(sectionNumber: SectionNumber): VisitIndex = sectionNumber.fold(unvisitClassic)(unvisitTaskList)
 
+  def removeIterationFull(sectionIndexToRemove: TemplateSectionIndex): VisitIndex =
+    fold[VisitIndex] { classic =>
+      VisitIndex.Classic(
+        classic.visitsIndex.filterNot(_.sectionIndex == sectionIndexToRemove)
+      )
+    } { taskList =>
+      VisitIndex.TaskList(
+        taskList.visitsIndex.map { case (key, value) =>
+          key -> value.filterNot(_.sectionIndex == sectionIndexToRemove)
+        }
+      )
+    }
+
   def removeIteration(
     sectionIndexToRemove: TemplateSectionIndex,
     iterationIndexToRemove: Int,


### PR DESCRIPTION
Fixed empty input when navigating back to populateAtl from final CYA page.
Probably fixed atl email duplication page not being displayed.